### PR TITLE
[auth] Add auth context and useSession hook

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,12 +1,15 @@
 import { Stack } from 'expo-router';
+import { AuthContextProvider } from '../utils/AuthContext';
 
 function StackLayout() {
   return (
-    <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      <Stack.Screen name="settings" options={{ headerShown: false }} />
-      <Stack.Screen name="auth" options={{ headerShown: false }} />
-    </Stack>
+    <AuthContextProvider>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="settings" options={{ headerShown: false }} />
+        <Stack.Screen name="auth" options={{ headerShown: false }} />
+      </Stack>
+    </AuthContextProvider>
   );
 }
 

--- a/src/app/auth/onboarding.tsx
+++ b/src/app/auth/onboarding.tsx
@@ -8,11 +8,7 @@ function OnboardingScreen() {
 
   return (
     <View>
-      {session && session.user ? (
-        <Account key={session.user.id} session={session} />
-      ) : (
-        <Login />
-      )}
+      {session && session.user ? <Account key={session.user.id} /> : <Login />}
     </View>
   );
 }

--- a/src/app/auth/onboarding.tsx
+++ b/src/app/auth/onboarding.tsx
@@ -1,22 +1,10 @@
-import { useState, useEffect } from 'react';
 import { View } from 'react-native';
-import { Session } from '@supabase/supabase-js';
-import supabase from '../../utils/supabase';
 import Login from '../../components/Login';
 import Account from '../../components/Account';
+import { useSession } from '../../utils/AuthContext';
 
 function OnboardingScreen() {
-  const [session, setSession] = useState<Session | null>(null);
-
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session: newSession } }) => {
-      setSession(newSession);
-    });
-
-    supabase.auth.onAuthStateChange((_event, newSession) => {
-      setSession(newSession);
-    });
-  }, []);
+  const { session } = useSession();
 
   return (
     <View>

--- a/src/app/auth/signup.tsx
+++ b/src/app/auth/signup.tsx
@@ -1,30 +1,14 @@
-import { Session } from '@supabase/supabase-js';
-import { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import Account from '../../components/Account';
 import Login from '../../components/Login';
-import supabase from '../../utils/supabase';
+import { useSession } from '../../utils/AuthContext';
 
 function SignUpScreen() {
-  const [session, setSession] = useState<Session | null>(null);
-
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session: newSession } }) => {
-      setSession(newSession);
-    });
-
-    supabase.auth.onAuthStateChange((_event, newSession) => {
-      setSession(newSession);
-    });
-  }, []);
+  const { session } = useSession();
 
   return (
     <View>
-      {session && session.user ? (
-        <Account key={session.user.id} session={session} />
-      ) : (
-        <Login />
-      )}
+      {session && session.user ? <Account key={session.user.id} /> : <Login />}
     </View>
   );
 }

--- a/src/components/Account.tsx
+++ b/src/components/Account.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
 import { StyleSheet, View, Alert, ScrollView, Platform } from 'react-native';
 import { Button, Input } from 'react-native-elements';
-import { Session } from '@supabase/supabase-js';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import supabase from '../utils/supabase';
 import UserStringInput from './UserStringInput';
+import { useSession } from '../utils/AuthContext';
 
 const styles = StyleSheet.create({
   container: {
@@ -21,7 +21,9 @@ const styles = StyleSheet.create({
   },
 });
 
-export default function Account({ session }: { session: Session }) {
+export default function Account() {
+  const { session, signOut } = useSession();
+
   const [loading, setLoading] = useState(true);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
@@ -160,7 +162,7 @@ export default function Account({ session }: { session: Session }) {
         />
       </View>
       <View style={styles.verticallySpaced}>
-        <Button title="Sign Out" onPress={() => supabase.auth.signOut()} />
+        <Button title="Sign Out" onPress={signOut} />
       </View>
     </ScrollView>
   );

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 import { Button, Input } from 'react-native-elements';
-import supabase from '../utils/supabase';
+import { useSession } from '../utils/AuthContext';
 
 const styles = StyleSheet.create({
   container: {
@@ -19,16 +19,14 @@ const styles = StyleSheet.create({
 });
 
 export default function Login() {
+  const sessionHandler = useSession();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
 
   const signInWithEmail = async () => {
     setLoading(true);
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
+    const { error } = await sessionHandler.signInWithEmail(email, password);
 
     if (error) Alert.alert(error.message);
     setLoading(false);
@@ -36,13 +34,16 @@ export default function Login() {
 
   const signUpWithEmail = async () => {
     setLoading(true);
-    const { error } = await supabase.auth.signUp({
-      email,
-      password,
-    });
+    const { error } = await sessionHandler.signUp(email, password);
 
-    if (error) Alert.alert(error.message);
-    console.error(error);
+    if (error) {
+      Alert.alert(error.message);
+      console.error(error);
+    } else {
+      Alert.alert(
+        'Please follow the directions in the confirmation email to activate your account.',
+      );
+    }
     setLoading(false);
   };
 

--- a/src/utils/AuthContext.tsx
+++ b/src/utils/AuthContext.tsx
@@ -67,13 +67,16 @@ export function AuthContextProvider({
     setSession(null);
   };
 
-  const authContextValue = useMemo(() => ({
+  const authContextValue = useMemo(
+    () => ({
       session,
       signUp,
       signIn,
       signInWithEmail,
       signOut,
-    }), [session]);
+    }),
+    [session],
+  );
 
   return (
     <AuthContext.Provider value={authContextValue}>

--- a/src/utils/AuthContext.tsx
+++ b/src/utils/AuthContext.tsx
@@ -1,0 +1,93 @@
+import { Session } from '@supabase/supabase-js';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+} from 'react';
+import supabase from './supabase';
+
+export interface AuthState {
+  session: Session | null;
+  isLoading: boolean;
+}
+enum AuthActionType {
+  SIGN_IN,
+  SIGN_OUT,
+}
+type AuthContextAction =
+  | { type: AuthActionType.SIGN_IN; session: Session }
+  | { type: AuthActionType.SIGN_OUT };
+
+const AuthContext = createContext({} as AuthState);
+
+const useAuthReducer = () =>
+  useReducer(
+    (prevState: AuthState, action: AuthContextAction) => {
+      switch (action.type) {
+        case AuthActionType.SIGN_IN:
+          return {
+            session: action.session,
+            isLoading: false,
+          };
+        case AuthActionType.SIGN_OUT:
+          return {
+            session: null,
+            isLoading: false,
+          };
+        default:
+          return prevState;
+      }
+    },
+    { session: null, isLoading: false },
+  );
+
+export function useSession() {
+  const value = useContext(AuthContext);
+  if (process.env.NODE_ENV !== 'production') {
+    if (!value) {
+      throw new Error(
+        'useSession must be wrapped in a <AuthContextProvider />',
+      );
+    }
+  }
+
+  return value;
+}
+
+export function AuthContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [authState, dispatch] = useAuthReducer();
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session: newSession } }) => {
+      if (newSession) {
+        dispatch({ type: AuthActionType.SIGN_IN, session: newSession });
+      }
+    });
+
+    supabase.auth.onAuthStateChange((_event, newSession) => {
+      if (newSession) {
+        dispatch({ type: AuthActionType.SIGN_IN, session: newSession });
+      }
+    });
+  }, []);
+
+  const authContextValue = useMemo(
+    () => ({
+      ...authState,
+      dispatch,
+    }),
+    [authState, dispatch],
+  );
+
+  return (
+    <AuthContext.Provider value={authContextValue}>
+      {children}
+    </AuthContext.Provider>
+  );
+}


### PR DESCRIPTION
# What's new in this PR

Adds `AuthContext` and `useSession` hook.
Implements the `useSession` hook in the sign-in components to have the same session functionality as before.

## Relevant Links

https://docs.expo.dev/router/reference/authentication/
https://github.com/calblueprint/vouchers4veggies/blob/227b8243945eed64fff278491aa2955fd2480719/src/screens/auth/LoginScreen.tsx#L22

### Notion Sprint Task

https://www.notion.so/calblueprint/auth-Implement-AuthContextProvider-0fa2ca72357b42c39af668d106ce2f48?pvs=4

### Online sources

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

https://docs.expo.dev/router/reference/authentication/

## How to review

Test sign-in and sign-up.
Main files to review: AuthContext.tsx, everything in the auth folder

## Next steps


## Tests Performed, Edge Cases

Tested the full authentication flow, including sign-up, sign-in, and edition profile details.

### Screenshots

N/A, same as before

CC: @akshaynthakur

[//]: # 'This tags in Akshay as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
