### PR TITLE
[story] Implement HTML parser to extract story content

### DIFF
--- a/src/app/(tabs)/search/story.tsx
+++ b/src/app/(tabs)/search/story.tsx
@@ -26,11 +26,10 @@ function StoryScreen() {
   const htmlParser = (html: string) => {
     const regex = /<p>(.*?)<\/p>/;
     const corresp = regex.exec(html);
-    const firstParagraph = (corresp) ? corresp[0] : "" // <p>text1</p>
-    const firstParagraphWithoutHtml = (corresp) ? corresp[1] : "" // text1
+    const firstParagraph = corresp ? corresp[0] : ''; // <p>text1</p>
+    const firstParagraphWithoutHtml = corresp ? corresp[1] : ''; // text1
     return firstParagraph;
   };
-  
 
   useEffect(() => {
     getStory('170947');

--- a/src/app/(tabs)/search/story.tsx
+++ b/src/app/(tabs)/search/story.tsx
@@ -4,6 +4,13 @@ import HTMLView from 'react-native-htmlview';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import globalStyles from '../../../styles/globalStyles';
 
+function htmlParser(html: string) {
+  const regex = /<h2(.*?)h2>(\n+<p(.*?)p>)+/; // regex grabs heading and paragraph tags for story
+  const corresp = regex.exec(html);
+  const story = corresp ? corresp[0] : ''; // <h2>heading<h2> <p>paragraph1</p> ...
+  return story;
+}
+
 function StoryScreen() {
   const [isLoading, setLoading] = useState(true);
   const [title, setTitle] = useState(String);
@@ -21,13 +28,6 @@ function StoryScreen() {
     } finally {
       setLoading(false);
     }
-  };
-
-  const htmlParser = (html: string) => {
-    const regex = /<h2(.*?)h2>(\n+<p(.*?)p>)+/; // regex grabs heading and paragraph tags for story
-    const corresp = regex.exec(html);
-    const story = corresp ? corresp[0] : ''; // <h2>heading<h2> <p>paragraph1</p> ...
-    return story;
   };
 
   useEffect(() => {

--- a/src/app/(tabs)/search/story.tsx
+++ b/src/app/(tabs)/search/story.tsx
@@ -30,13 +30,6 @@ function StoryScreen() {
     }
   };
 
-  const htmlParser = (html: string) => {
-    const regex = /<h2(.*?)h2>(\n+<p(.*?)p>)+/; // regex grabs heading and paragraph tags for story
-    const corresp = regex.exec(html);
-    const story = corresp ? corresp[0] : ''; // <h2>heading<h2> <p>paragraph1</p> ...
-    return story;
-  };
-
   useEffect(() => {
     getStory('170947');
   }, []);

--- a/src/app/(tabs)/search/story.tsx
+++ b/src/app/(tabs)/search/story.tsx
@@ -23,6 +23,15 @@ function StoryScreen() {
     }
   };
 
+  const htmlParser = (html: string) => {
+    const regex = /<p>(.*?)<\/p>/;
+    const corresp = regex.exec(html);
+    const firstParagraph = (corresp) ? corresp[0] : "" // <p>text1</p>
+    const firstParagraphWithoutHtml = (corresp) ? corresp[1] : "" // text1
+    return firstParagraph;
+  };
+  
+
   useEffect(() => {
     getStory('170947');
   }, []);
@@ -34,7 +43,7 @@ function StoryScreen() {
       ) : (
         <ScrollView>
           <HTMLView value={title} />
-          <HTMLView value={content} />
+          <HTMLView value={htmlParser(content)} />
         </ScrollView>
       )}
     </SafeAreaView>

--- a/src/app/(tabs)/search/story.tsx
+++ b/src/app/(tabs)/search/story.tsx
@@ -24,11 +24,11 @@ function StoryScreen() {
   };
 
   const htmlParser = (html: string) => {
-    const regex = /<p>(.*?)<\/p>/;
+    const regex = /<h2(.*?)h2>(\n+<p(.*?)p>)+/; // <p>.*?<\/p>/;
     const corresp = regex.exec(html);
     const firstParagraph = corresp ? corresp[0] : ''; // <p>text1</p>
     const firstParagraphWithoutHtml = corresp ? corresp[1] : ''; // text1
-    return firstParagraph;
+    return corresp[0];
   };
 
   useEffect(() => {
@@ -43,6 +43,7 @@ function StoryScreen() {
         <ScrollView>
           <HTMLView value={title} />
           <HTMLView value={htmlParser(content)} />
+          {/* <HTMLView value={htmlParser(content)} /> */}
         </ScrollView>
       )}
     </SafeAreaView>

--- a/src/app/(tabs)/search/story.tsx
+++ b/src/app/(tabs)/search/story.tsx
@@ -24,11 +24,10 @@ function StoryScreen() {
   };
 
   const htmlParser = (html: string) => {
-    const regex = /<h2(.*?)h2>(\n+<p(.*?)p>)+/; // <p>.*?<\/p>/;
+    const regex = /<h2(.*?)h2>(\n+<p(.*?)p>)+/; // regex grabs heading and paragraph tags for story
     const corresp = regex.exec(html);
-    const firstParagraph = corresp ? corresp[0] : ''; // <p>text1</p>
-    const firstParagraphWithoutHtml = corresp ? corresp[1] : ''; // text1
-    return corresp[0];
+    const story = corresp ? corresp[0] : ''; // <h2>heading<h2> <p>paragraph1</p> ...
+    return story;
   };
 
   useEffect(() => {
@@ -43,7 +42,6 @@ function StoryScreen() {
         <ScrollView>
           <HTMLView value={title} />
           <HTMLView value={htmlParser(content)} />
-          {/* <HTMLView value={htmlParser(content)} /> */}
         </ScrollView>
       )}
     </SafeAreaView>


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"
# [story] Implement HTML parser to extract story content

# What's new in this PR

Content was being pulled in a messy HTML formatted string. I created a function that parses through this screen and only obtains the heading long with the actual story (includes the \<h2\> and \<p\> tag content). Another imported HTML tag displays the string how it is formatted through HTML.

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links

### Notion Sprint Task
[https://www.notion.so/calblueprint/story-Implement-HTML-parser-to-extract-story-content-b764c72759614a4cb0fa66fdb44fd7d2](url)

### Online sources
[https://stackoverflow.com/questions/61791863/how-to-extract-the-content-of-the-first-paragraph-in-html-string-react-native](url)
[https://stackoverflow.com/questions/432493/how-do-you-access-the-matched-groups-in-a-javascript-regular-expression](url)

### Related PRs

## How to review
Open application and head to the story section. By default, the "It's Carnival" story should display with the title and the actual content of the story in a plain formatted way. However, there should be no ASCII characters or HTML tags.

## Next steps
Go from WordPress API to Supabase API by changing the method in which we grab data.

## Tests Performed, Edge Cases

### Screenshots
video:
https://github.com/calblueprint/girls-write-now/assets/69034384/f164a474-d01d-48d7-83b2-02421fd1e0a3

![IMG_1868](https://github.com/calblueprint/girls-write-now/assets/69034384/0ef77e50-4c81-4107-b7d2-19960179bc83)

CC: @akshaynthakur

[//]: # 'This tags in Akshay as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
