### PR TITLE
[settings] Fix nav so that settings screen is independent from onboarding screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "expo-status-bar": "~1.6.0",
         "html-entities": "^2.4.0",
         "react": "18.2.0",
-        "react-native": "0.72.5",
+        "react-native": "0.72.6",
         "react-native-dom-parser": "^1.5.3",
         "react-native-elements": "^3.4.3",
         "react-native-gesture-handler": "~2.12.0",
@@ -16049,9 +16049,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-native": {
-      "version": "0.72.5",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.72.5.tgz",
-      "integrity": "sha512-oIewslu5DBwOmo7x5rdzZlZXCqDIna0R4dUwVpfmVteORYLr4yaZo5wQnMeR+H7x54GaMhmgeqp0ZpULtulJFg==",
+      "version": "0.72.6",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.72.6.tgz",
+      "integrity": "sha512-RafPY2gM7mcrFySS8TL8x+TIO3q7oAlHpzEmC7Im6pmXni6n1AuufGaVh0Narbr1daxstw7yW7T9BKW5dpVc2A==",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.2.1",
         "@react-native-community/cli": "11.3.7",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "expo-status-bar": "~1.6.0",
     "html-entities": "^2.4.0",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-dom-parser": "^1.5.3",
     "react-native-elements": "^3.4.3",
     "react-native-gesture-handler": "~2.12.0",

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -1,14 +1,14 @@
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { Redirect, router } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { Text, View, Alert, ScrollView, Platform } from 'react-native';
+import { Text, View, Alert, Platform } from 'react-native';
 import { Button, Input } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import UserStringInput from '../components/UserStringInput';
 import globalStyles from '../styles/globalStyles';
 import { useSession } from '../utils/AuthContext';
 import supabase from '../utils/supabase';
-import UserStringInput from '../components/UserStringInput';
 
 function SettingsScreen() {
   const { session, signOut } = useSession();

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -1,14 +1,55 @@
-import { router } from 'expo-router';
-import { useEffect } from 'react';
-import { Text, View } from 'react-native';
-import { Button } from 'react-native-elements';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { Redirect, router } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Text, View, Alert, ScrollView, Platform } from 'react-native';
+import { Button, Input } from 'react-native-elements';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import globalStyles from '../styles/globalStyles';
 import { useSession } from '../utils/AuthContext';
+import supabase from '../utils/supabase';
+import UserStringInput from '../components/UserStringInput';
 
 function SettingsScreen() {
   const { session, signOut } = useSession();
+  const [loading, setLoading] = useState(true);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [birthday, setBirthday] = useState(new Date());
+  const [gender, setGender] = useState('');
+  const [raceEthnicity, setRaceEthnicity] = useState('');
+  const [showDatePicker, setShowDatePicker] = useState(Platform.OS === 'ios');
+
+  const getProfile = async () => {
+    try {
+      setLoading(true);
+      if (!session?.user) throw new Error('No user on the session!');
+
+      const { data, error, status } = await supabase
+        .from('profiles')
+        .select(`first_name, last_name, birthday, gender, race_ethnicity`)
+        .eq('user_id', session?.user.id)
+        .single();
+
+      if (error && status !== 406 && error instanceof Error) {
+        throw error;
+      }
+
+      if (data) {
+        setFirstName(data.first_name || firstName);
+        setLastName(data.last_name || lastName);
+        setBirthday(new Date(data.birthday) || birthday);
+        setGender(data.gender || gender);
+        setRaceEthnicity(data.race_ethnicity || raceEthnicity);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        Alert.alert(`Get profile error: ${error.message}`);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const resetAndPushToRouter = (path: string) => {
     while (router.canGoBack()) {
@@ -18,17 +59,113 @@ function SettingsScreen() {
   };
 
   useEffect(() => {
+    if (session) getProfile();
+  }, [session]);
+
+  useEffect(() => {
     if (!session) resetAndPushToRouter('/auth/login');
   }, [session]);
+
+  const updateProfile = async () => {
+    try {
+      setLoading(true);
+      if (!session?.user) throw new Error('No user on the session!');
+
+      // Only update values that are not blank
+      const updates = {
+        ...(firstName && { first_name: firstName }),
+        ...(lastName && { last_name: lastName }),
+        ...(gender && { gender }),
+        ...(raceEthnicity && { race_ethnicity: raceEthnicity }),
+        ...(birthday && { birthday }),
+      };
+
+      // Check if user exists
+      const { count } = await supabase
+        .from('profiles')
+        .select(`*`, { count: 'exact' })
+        .eq('user_id', session?.user.id);
+
+      if (count && count >= 1) {
+        // Update user if they exist
+        const { error } = await supabase
+          .from('profiles')
+          .update(updates)
+          .eq('user_id', session?.user.id)
+          .select('*');
+
+        if (error && error instanceof Error) throw error;
+      } else {
+        // Create user if they don't exist
+        const { error } = await supabase.from('profiles').insert(updates);
+
+        if (error && error instanceof Error) throw error;
+      }
+
+      Alert.alert('Succesfully updated account!');
+    } catch (error) {
+      if (error instanceof Error) {
+        Alert.alert(error.message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!session) {
+    return <Redirect href="/auth/login" />;
+  }
 
   return (
     <SafeAreaView style={globalStyles.container}>
       <Text style={globalStyles.h1}>Settings</Text>
-      <View>
+      <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
+        <Input label="Email" value={session?.user?.email} disabled />
+      </View>
+      <UserStringInput
+        label="First Name"
+        value={firstName}
+        onChange={setFirstName}
+      />
+      <UserStringInput
+        label="Last Name"
+        value={lastName}
+        onChange={setLastName}
+      />
+      <UserStringInput label="Gender" value={gender} onChange={setGender} />
+      <UserStringInput
+        label="Race/Ethnicity"
+        value={raceEthnicity}
+        onChange={setRaceEthnicity}
+      />
+
+      {Platform.OS !== 'ios' && (
         <Button
-          title="Update Profile"
-          onPress={() => router.push('/auth/onboarding')}
+          title="Change Birthday"
+          onPress={() => setShowDatePicker(true)}
         />
+      )}
+      {showDatePicker && (
+        <DateTimePicker
+          testID="dateTimePicker"
+          value={birthday}
+          mode="date"
+          onChange={date => {
+            setShowDatePicker(Platform.OS === 'ios');
+            if (date.nativeEvent.timestamp) {
+              setBirthday(new Date(date.nativeEvent.timestamp));
+            }
+          }}
+        />
+      )}
+      <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
+        <Button
+          title={loading ? 'Loading ...' : 'Update profile'}
+          onPress={updateProfile}
+          disabled={loading}
+        />
+      </View>
+      <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
         <Button title="Sign Out" onPress={signOut} />
       </View>
     </SafeAreaView>


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

Changed the settings screen to include options to change user data.

## Relevant Links

None

### Notion Sprint Task

[Notion link](https://www.notion.so/calblueprint/settings-Fix-nav-so-that-settings-screen-is-independent-from-onboarding-screen-7901702275364651ad636598d9257d60?pvs=4)

[//]: # 'Add the relevant Notion link(s) here'

### Online sources

None

### Related PRs
None

## How to review

- Sign in and go to the settings screen
- Edit each data entry and click update profile
- Close the app and reopen the app
- Go back to the settings screen to see if the new information is shown to make sure the data persisted

## Next steps

None

## Tests Performed, Edge Cases
None

### Screenshots

![IMG_EC10C211CBBE-1](https://github.com/calblueprint/girls-write-now/assets/34043950/6f19f1d0-cbb7-4348-b1c1-4d668c10819f)


CC: @akshaynthakur

[//]: # 'This tags in Akshay as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
