### PR TITLE
[search] Link search results to story screen

### DIFF
--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -59,18 +59,6 @@ function SearchScreen() {
         onChangeText={text => searchFunction(text)}
         value={search}
       />
-      <Link href="/story" asChild>
-        <Button title="Story" />
-      </Link>
-      {/* <Button
-        title="Params Test"
-        onPress={() =>
-          router.push({ pathname: '/story', params: { authorID: 1778 } })
-        }
-      /> */}
-      <Link href={`/story?author=${1178}`} asChild>
-        <Button title="Story" />
-      </Link>
       <Button
         title="Show Filter Modal"
         onPress={() => setFilterVisible(true)}
@@ -86,7 +74,12 @@ function SearchScreen() {
             image={item.featured_media}
             authorImage={item.author_image}
             tags={item.genre_medium}
-            pressFunction={() => null}
+            pressFunction={() =>
+              router.push({
+                pathname: '/story',
+                params: { storyId: item.id.toString() },
+              })
+            }
           />
         )}
       />

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -1,5 +1,5 @@
 import { SearchBar } from '@rneui/themed';
-import { Link } from 'expo-router';
+import { Link, router } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { Button, FlatList, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -60,6 +60,15 @@ function SearchScreen() {
         value={search}
       />
       <Link href="/story" asChild>
+        <Button title="Story" />
+      </Link>
+      {/* <Button
+        title="Params Test"
+        onPress={() =>
+          router.push({ pathname: '/story', params: { authorID: 1778 } })
+        }
+      /> */}
+      <Link href={`/story?author=${1178}`} asChild>
         <Button title="Story" />
       </Link>
       <Button

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -38,7 +38,7 @@ function SearchScreen() {
       const data: StoryPreview[] = await fetchAllStoryPreviews();
       setAllStories(data);
     })();
-  });
+  }, []);
 
   return (
     <SafeAreaView style={styles.container}>

--- a/src/app/(tabs)/story/index.tsx
+++ b/src/app/(tabs)/story/index.tsx
@@ -1,3 +1,4 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
@@ -19,6 +20,10 @@ function StoryScreen() {
   const [isLoading, setLoading] = useState(true);
   const scrollRef = React.useRef<any>(null);
   const [story, setStory] = useState<any>();
+
+  const params = useLocalSearchParams();
+  const { author } = params;
+  const router = useRouter();
 
   const onShare = async () => {
     try {
@@ -61,6 +66,7 @@ function StoryScreen() {
           <Image style={styles.image} source={{ uri: story.featured_media }} />
 
           <Text style={styles.title}>{story.title}</Text>
+          <Text>{author}</Text>
 
           <View style={styles.author}>
             <Image style={styles.authorImage} source={{ uri: '' }} />

--- a/src/app/(tabs)/story/index.tsx
+++ b/src/app/(tabs)/story/index.tsx
@@ -20,7 +20,7 @@ import { Story } from '../../../queries/types';
 function StoryScreen() {
   const [isLoading, setLoading] = useState(true);
   const scrollRef = React.useRef<any>(null);
-  const [story, setStory] = useState<Story>();
+  const [story, setStory] = useState<Story>({} as Story);
 
   const params = useLocalSearchParams<{ storyId: string }>();
   const { storyId } = params;
@@ -42,7 +42,7 @@ function StoryScreen() {
   const onShare = async () => {
     try {
       const result = await Share.share({
-        message: `Check out this story from Girls Write Now!!!\n${story?.link}/`,
+        message: `Check out this story from Girls Write Now!!!\n${story.link}/`,
       });
       if (result.action === Share.sharedAction) {
         if (result.activityType) {
@@ -68,23 +68,23 @@ function StoryScreen() {
           ref={scrollRef}
           showsVerticalScrollIndicator={false}
         >
-          <Image style={styles.image} source={{ uri: story?.featured_media }} />
+          <Image style={styles.image} source={{ uri: story.featured_media }} />
 
           <Text style={styles.title}>{story?.title}</Text>
 
           <View style={styles.author}>
             <Image
               style={styles.authorImage}
-              source={{ uri: story?.author_image }}
+              source={{ uri: story.author_image }}
             />
-            <Text style={styles.authorText}>By {story?.author_name}</Text>
+            <Text style={styles.authorText}>By {story.author_name}</Text>
           </View>
 
           <View>
             <FlatList
               style={styles.genres}
               horizontal
-              data={story?.genre_medium}
+              data={story.genre_medium}
               renderItem={({ item }) => (
                 <View style={styles.genresBorder}>
                   <Text style={styles.genresText}>{item}</Text>
@@ -103,9 +103,9 @@ function StoryScreen() {
             </Button>
           </View>
 
-          <RenderHTML source={story!.excerpt} baseStyle={styles.excerpt} />
+          <RenderHTML source={story.excerpt} baseStyle={styles.excerpt} />
 
-          <RenderHTML source={story!.content} baseStyle={styles.story} />
+          <RenderHTML source={story.content} baseStyle={styles.story} />
 
           <Button
             textColor="black"
@@ -119,14 +119,14 @@ function StoryScreen() {
 
           <Text style={styles.authorProcess}>Author's Process</Text>
 
-          <RenderHTML source={story!.process} baseStyle={styles.process} />
+          <RenderHTML source={story.process} baseStyle={styles.process} />
 
           <View style={styles.author}>
             <Image
               style={styles.authorImage}
-              source={{ uri: story?.author_image }}
+              source={{ uri: story.author_image }}
             />
-            <Text style={styles.authorText}>By {story?.author_name}</Text>
+            <Text style={styles.authorText}>By {story.author_name}</Text>
           </View>
 
           <Button

--- a/src/queries/stories.tsx
+++ b/src/queries/stories.tsx
@@ -1,4 +1,4 @@
-import { StoryPreview } from './types';
+import { Story, StoryPreview } from './types';
 import supabase from '../utils/supabase';
 
 export async function fetchAllStoryPreviews(): Promise<StoryPreview[]> {
@@ -10,6 +10,22 @@ export async function fetchAllStoryPreviews(): Promise<StoryPreview[]> {
       `An error occured when trying to fetch all story previews: ${error}`,
     );
   } else {
+    return data;
+  }
+}
+
+export async function fetchStory(storyId: number): Promise<Story[]> {
+  const { data, error } = await supabase.rpc('fetch_story', {
+    input_id: storyId,
+  });
+
+  if (error) {
+    console.log(error);
+    throw new Error(
+      `An error occured when trying to fetch story ${storyId}: ${error.code}`,
+    );
+  } else {
+    console.log(data);
     return data;
   }
 }

--- a/src/queries/types.tsx
+++ b/src/queries/types.tsx
@@ -2,10 +2,28 @@ export interface StoryPreview {
   id: number;
   date: string;
   title: string;
+  excerpt: { html: string };
   featured_media: string;
   author_name: string;
   author_image: string;
   topic: string[];
   tone: string[];
   genre_medium: string[];
+}
+
+export interface Story {
+  id: number;
+  date: string;
+  title: string;
+  featured_media: string;
+  author_id: number;
+  author_name: string;
+  author_image: string;
+  topic: string[];
+  tone: string[];
+  genre_medium: string[];
+  excerpt: { html: string };
+  content: { html: string };
+  process: { html: string };
+  link: string;
 }


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
- Implement fetch_story query that returns a Story object based on story ID
- Implement routing with params passed between search screen and story screen
- Updated types of excerpt, content, and story in the schema to be `jsonb` instead of `text`

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links
N/A

### Notion Sprint Task
N/A

[//]: # 'Add the relevant Notion link(s) here'

### Online sources
- https://expo.github.io/router/docs/migration/react-navigation/params/

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
- Building on #29 and #27 

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## How to review
- Test that onPress functions work for every search result card, story that's rendered is the story card that was clicked on
- The `story` useState can be null, which means that when I'm trying to render parts of it I'm doing a lot of null checking or non-null assertion. Just want to make sure this is ok or use a better method if one exists

[//]: # 'The order in which to review files and what to expect when testing locally'

## Next steps
N/A

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

## Tests Performed, Edge Cases
N/A

[//]: # 'Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally'

### Screenshots

https://github.com/calblueprint/girls-write-now/assets/78326649/bcc8dec3-99e6-4d00-94f6-78bbfa029a1a


[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @akshaynthakur

[//]: # 'This tags in Akshay as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
