### PR TITLE
[auth] Implement useReducer to organize AuthContext functions

### DIFF
--- a/src/app/auth/forgotPassword.tsx
+++ b/src/app/auth/forgotPassword.tsx
@@ -5,17 +5,22 @@ import { Button, Input } from 'react-native-elements';
 
 import globalStyles from '../../styles/globalStyles';
 import { useSession } from '../../utils/AuthContext';
+import {
+  resetPassword,
+  signOut,
+  updateUser,
+  verifyOtp,
+} from '../../queries/auth';
 
 function ForgotPasswordScreen() {
   const { dispatch, isLoading } = useSession();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [loading, setLoading] = useState(false);
   const [verificationCode, setCode] = useState<string>('');
   const [changingPassword, setChangingPassword] = useState(false);
 
   const sendResetEmail = async () => {
-    const { error } = await resetPassword(email);
+    const { error } = await resetPassword(dispatch, email);
     if (error)
       Alert.alert('Could not send a reset password email. Please try again.');
     else
@@ -24,10 +29,8 @@ function ForgotPasswordScreen() {
       );
   };
   const verifyCode = async () => {
-    setLoading(true);
-
     if (email && verificationCode) {
-      const { error } = await verifyOtp(email, verificationCode);
+      const { error } = await verifyOtp(dispatch, email, verificationCode);
 
       if (error) {
         Alert.alert(error.message);
@@ -40,23 +43,18 @@ function ForgotPasswordScreen() {
     } else {
       Alert.alert(`Please sign up again.`);
     }
-
-    setLoading(false);
   };
 
   const changePassword = async () => {
-    setLoading(true);
-    const { error } = await updateUser({ password });
+    const { error } = await updateUser(dispatch, { password });
 
     if (error) {
       console.error(error);
       Alert.alert('Updating password failed');
     } else {
-      await signOut();
+      await signOut(dispatch);
       router.replace('/auth/login');
     }
-
-    setLoading(false);
   };
 
   return (
@@ -72,7 +70,7 @@ function ForgotPasswordScreen() {
         />
       </View>
       <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
-        <Button title="Send" disabled={loading} onPress={sendResetEmail} />
+        <Button title="Send" disabled={isLoading} onPress={sendResetEmail} />
       </View>
 
       <TextInput
@@ -85,7 +83,7 @@ function ForgotPasswordScreen() {
       />
 
       <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
-        <Button title="Verify" disabled={loading} onPress={verifyCode} />
+        <Button title="Verify" disabled={isLoading} onPress={verifyCode} />
       </View>
 
       {changingPassword && (
@@ -105,7 +103,7 @@ function ForgotPasswordScreen() {
           <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
             <Button
               title="Change Password"
-              disabled={loading}
+              disabled={isLoading}
               onPress={changePassword}
             />
           </View>

--- a/src/app/auth/forgotPassword.tsx
+++ b/src/app/auth/forgotPassword.tsx
@@ -7,7 +7,7 @@ import globalStyles from '../../styles/globalStyles';
 import { useSession } from '../../utils/AuthContext';
 
 function ForgotPasswordScreen() {
-  const { updateUser, signOut, resetPassword, verifyOtp } = useSession();
+  const { dispatch, isLoading } = useSession();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);

--- a/src/app/auth/login.tsx
+++ b/src/app/auth/login.tsx
@@ -1,5 +1,5 @@
 import { Link, router } from 'expo-router';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, View } from 'react-native';
 import { Button, Input } from 'react-native-elements';
 
@@ -7,10 +7,9 @@ import globalStyles from '../../styles/globalStyles';
 import { useSession } from '../../utils/AuthContext';
 
 function LoginScreen() {
-  const sessionHandler = useSession();
+  const { dispatch, isLoading, session, error } = useSession();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [loading, setLoading] = useState(false);
 
   const resetAndPushToRouter = (path: string) => {
     while (router.canGoBack()) {
@@ -20,13 +19,21 @@ function LoginScreen() {
   };
 
   const signInWithEmail = async () => {
-    setLoading(true);
-    const { error } = await sessionHandler.signInWithEmail(email, password);
-
-    if (error) Alert.alert(error.message);
-    else resetAndPushToRouter('/home');
-    setLoading(false);
+    dispatch({ type: 'SIGN_IN_WITH_EMAIL', email, password });
   };
+
+  useEffect(() => {
+    if (error) {
+      Alert.alert(error.message);
+    }
+  }, [error]);
+
+  useEffect(() => {
+    console.log(session);
+    if (session) {
+      resetAndPushToRouter('/home');
+    }
+  }, [session]);
 
   return (
     <View style={globalStyles.auth_container}>
@@ -53,7 +60,7 @@ function LoginScreen() {
       </View>
       <Link href="/auth/forgotPassword">Forgot password?</Link>
       <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
-        <Button title="Log In" disabled={loading} onPress={signInWithEmail} />
+        <Button title="Log In" disabled={isLoading} onPress={signInWithEmail} />
       </View>
       <Link href="/auth/signup">Don&apos;t have an account? Sign Up</Link>
     </View>

--- a/src/app/auth/login.tsx
+++ b/src/app/auth/login.tsx
@@ -1,13 +1,14 @@
 import { Link, router } from 'expo-router';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Alert, View } from 'react-native';
 import { Button, Input } from 'react-native-elements';
 
 import globalStyles from '../../styles/globalStyles';
 import { useSession } from '../../utils/AuthContext';
+import { signInWithEmail } from '../../queries/auth';
 
 function LoginScreen() {
-  const { dispatch, isLoading, session, error } = useSession();
+  const { dispatch, isLoading } = useSession();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
@@ -18,22 +19,12 @@ function LoginScreen() {
     router.replace(path);
   };
 
-  const signInWithEmail = async () => {
-    dispatch({ type: 'SIGN_IN_WITH_EMAIL', email, password });
+  const signIn = async () => {
+    const { error } = await signInWithEmail(dispatch, email, password);
+
+    if (error) Alert.alert(error.message);
+    else resetAndPushToRouter('/home');
   };
-
-  useEffect(() => {
-    if (error) {
-      Alert.alert(error.message);
-    }
-  }, [error]);
-
-  useEffect(() => {
-    console.log(session);
-    if (session) {
-      resetAndPushToRouter('/home');
-    }
-  }, [session]);
 
   return (
     <View style={globalStyles.auth_container}>
@@ -60,7 +51,7 @@ function LoginScreen() {
       </View>
       <Link href="/auth/forgotPassword">Forgot password?</Link>
       <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
-        <Button title="Log In" disabled={isLoading} onPress={signInWithEmail} />
+        <Button title="Log In" disabled={isLoading} onPress={signIn} />
       </View>
       <Link href="/auth/signup">Don&apos;t have an account? Sign Up</Link>
     </View>

--- a/src/app/auth/signup.tsx
+++ b/src/app/auth/signup.tsx
@@ -1,33 +1,28 @@
 import { Redirect, Link, router } from 'expo-router';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Alert, View } from 'react-native';
 import { Button, Input } from 'react-native-elements';
 
 import globalStyles from '../../styles/globalStyles';
 import { useSession } from '../../utils/AuthContext';
+import { signUp } from '../../queries/auth';
 
 function SignUpScreen() {
-  const { session, dispatch, isLoading, error } = useSession();
+  const { session, isLoading, dispatch } = useSession();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const attemptedSignUp = useRef(false);
 
   if (session) {
     return <Redirect href="/home" />;
   }
 
   const signUpWithEmail = async () => {
-    dispatch({ type: 'SIGN_UP', email, password });
-    attemptedSignUp.current = true;
-  };
-
-  useEffect(() => {
-    if (!attemptedSignUp.current) return;
+    const { error } = await signUp(dispatch, email, password);
 
     if (error) Alert.alert(error.message);
     else router.replace('/auth/verify');
-  }, [error]);
+  };
 
   return (
     <View style={globalStyles.auth_container}>

--- a/src/app/auth/signup.tsx
+++ b/src/app/auth/signup.tsx
@@ -1,5 +1,5 @@
 import { Redirect, Link, router } from 'expo-router';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Alert, View } from 'react-native';
 import { Button, Input } from 'react-native-elements';
 
@@ -7,25 +7,27 @@ import globalStyles from '../../styles/globalStyles';
 import { useSession } from '../../utils/AuthContext';
 
 function SignUpScreen() {
-  const { session, signUp } = useSession();
+  const { session, dispatch, isLoading, error } = useSession();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [loading, setLoading] = useState(false);
+  const attemptedSignUp = useRef(false);
 
   if (session) {
     return <Redirect href="/home" />;
   }
 
   const signUpWithEmail = async () => {
-    setLoading(true);
-    const { error } = await signUp(email, password);
+    dispatch({ type: 'SIGN_UP', email, password });
+    attemptedSignUp.current = true;
+  };
+
+  useEffect(() => {
+    if (!attemptedSignUp.current) return;
 
     if (error) Alert.alert(error.message);
     else router.replace('/auth/verify');
-
-    setLoading(false);
-  };
+  }, [error]);
 
   return (
     <View style={globalStyles.auth_container}>
@@ -55,7 +57,7 @@ function SignUpScreen() {
         <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
           <Button
             title="Sign Up"
-            disabled={loading}
+            disabled={isLoading}
             onPress={signUpWithEmail}
           />
         </View>

--- a/src/app/auth/verify.tsx
+++ b/src/app/auth/verify.tsx
@@ -5,17 +5,15 @@ import { Button } from 'react-native-elements';
 
 import globalStyles from '../../styles/globalStyles';
 import { useSession } from '../../utils/AuthContext';
+import { resendVerification, verifyOtp } from '../../queries/auth';
 
 function VerificationScreen() {
-  const { user, verifyOtp, resendVerification } = useSession();
-  const [loading, setLoading] = useState(false);
+  const { user, dispatch, isLoading } = useSession();
   const [verificationCode, setCode] = useState<string>('');
 
   const verifyAccount = async () => {
-    setLoading(true);
-
     if (user?.email && verificationCode) {
-      const { error } = await verifyOtp(user.email, verificationCode);
+      const { error } = await verifyOtp(dispatch, user.email, verificationCode);
 
       if (error) Alert.alert(error.message);
       else router.replace('/auth/onboarding');
@@ -24,15 +22,11 @@ function VerificationScreen() {
     } else {
       Alert.alert(`Please sign up again.`);
     }
-
-    setLoading(false);
   };
 
   const resendCode = async () => {
-    setLoading(true);
-
     if (user?.email) {
-      const { error, data } = await resendVerification(user.email);
+      const { error, data } = await resendVerification(dispatch, user.email);
 
       console.log(data);
       if (error) Alert.alert(error.message);
@@ -40,8 +34,6 @@ function VerificationScreen() {
     } else {
       Alert.alert(`Please sign up again.`);
     }
-
-    setLoading(false);
   };
 
   return (
@@ -57,12 +49,12 @@ function VerificationScreen() {
 
       <View style={[globalStyles.verticallySpaced, globalStyles.mt20]} />
       <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
-        <Button title="Resend code" disabled={loading} onPress={resendCode} />
+        <Button title="Resend code" disabled={isLoading} onPress={resendCode} />
       </View>
       <View style={[globalStyles.verticallySpaced, globalStyles.mt20]}>
         <Button
           title="Verify Account"
-          disabled={loading}
+          disabled={isLoading}
           onPress={verifyAccount}
         />
       </View>

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -11,7 +11,7 @@ import { useSession } from '../utils/AuthContext';
 import supabase from '../utils/supabase';
 
 function SettingsScreen() {
-  const { session, signOut } = useSession();
+  const { dispatch, user, session } = useSession();
   const [loading, setLoading] = useState(true);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
@@ -23,12 +23,12 @@ function SettingsScreen() {
   const getProfile = async () => {
     try {
       setLoading(true);
-      if (!session?.user) throw new Error('No user on the session!');
+      if (!user) throw new Error('No user on the session!');
 
       const { data, error, status } = await supabase
         .from('profiles')
         .select(`first_name, last_name, birthday, gender, race_ethnicity`)
-        .eq('user_id', session?.user.id)
+        .eq('user_id', user?.id)
         .single();
 
       if (error && status !== 406 && error instanceof Error) {
@@ -164,7 +164,10 @@ function SettingsScreen() {
           onPress={updateProfile}
           disabled={loading}
         />
-        <Button title="Sign Out" onPress={signOut} />
+        <Button
+          title="Sign Out"
+          onPress={() => dispatch({ type: 'SIGN_OUT' })}
+        />
       </View>
     </SafeAreaView>
   );

--- a/src/queries/auth.tsx
+++ b/src/queries/auth.tsx
@@ -1,0 +1,90 @@
+import { UserAttributes } from '@supabase/supabase-js';
+import supabase from '../utils/supabase';
+import { AuthDispatch, useAuthReducer } from '../utils/AuthContext';
+
+export const signInWithEmail = async (
+  dispatch: AuthDispatch,
+  email: string,
+  password: string,
+) => {
+  dispatch({ type: 'LOADING' });
+  const value = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  dispatch({ type: 'SIGN_IN_WITH_EMAIL' });
+  return value;
+};
+
+export const signUp = async (
+  dispatch: AuthDispatch,
+  email: string,
+  password: string,
+) => {
+  dispatch({ type: 'LOADING' });
+  const value = await supabase.auth.signUp({
+    email,
+    password,
+  });
+  dispatch({ type: 'SIGN_UP' });
+
+  return value;
+};
+
+export const signOut = async (dispatch: AuthDispatch) => {
+  dispatch({ type: 'LOADING' });
+  const value = await supabase.auth.signOut();
+  dispatch({ type: 'SIGN_OUT' });
+
+  return value;
+};
+
+export const verifyOtp = async (
+  dispatch: AuthDispatch,
+  email: string,
+  token: string,
+) => {
+  dispatch({ type: 'LOADING' });
+  const value = await supabase.auth.verifyOtp({
+    email,
+    token,
+    type: 'email',
+  });
+  dispatch({ type: 'VERIFY_OTP' });
+
+  return value;
+};
+
+export const resendVerification = async (
+  dispatch: AuthDispatch,
+  email: string,
+) => {
+  dispatch({ type: 'LOADING' });
+  const value = await supabase.auth.resend({
+    type: 'signup',
+    email,
+  });
+  dispatch({ type: 'VERIFY_OTP' });
+
+  return value;
+};
+
+export const resetPassword = async (dispatch: AuthDispatch, email: string) => {
+  dispatch({ type: 'LOADING' });
+  const value = await supabase.auth.resetPasswordForEmail(email);
+  dispatch({ type: 'RESET_PASSWORD' });
+
+  return value;
+};
+
+export const updateUser = async (
+  dispatch: AuthDispatch,
+  attributes: UserAttributes,
+) => {
+  dispatch({ type: 'LOADING' });
+  const value = await supabase.auth.updateUser(attributes);
+  dispatch({ type: 'UPDATE_USER', user: value.data?.user });
+
+  return value;
+};

--- a/src/utils/AuthContext.tsx
+++ b/src/utils/AuthContext.tsx
@@ -1,10 +1,8 @@
 import {
   AuthError,
-  AuthResponse,
   Session,
   User,
   UserAttributes,
-  UserResponse,
 } from '@supabase/supabase-js';
 import React, {
   createContext,
@@ -12,20 +10,44 @@ import React, {
   useEffect,
   useMemo,
   useReducer,
-  useState,
 } from 'react';
 
 import supabase from './supabase';
 
 type AuthContextAction =
   | { type: 'LOADING' }
-  | { type: 'SIGN_UP'; email: string; password: string }
-  | { type: 'SIGN_IN_WITH_EMAIL'; email: string; password: string }
-  | { type: 'VERIFY_OTP'; email: string; token: string }
-  | { type: 'RESEND_VERIFICATION'; email: string }
-  | { type: 'RESET_PASSWORD'; email: string }
-  | { type: 'UPDATE_USER'; attributes: UserAttributes }
-  | { type: 'SIGN_OUT' };
+  | { type: 'CLEAR_ERROR' }
+  | {
+      type: 'SIGN_UP';
+      email: string;
+      password: string;
+      error?: AuthError | null;
+    }
+  | {
+      type: 'SIGN_IN_WITH_EMAIL';
+      email: string;
+      password: string;
+      error?: AuthError | null;
+    }
+  | {
+      type: 'VERIFY_OTP';
+      email: string;
+      token: string;
+      error?: AuthError | null;
+    }
+  | { type: 'RESEND_VERIFICATION'; email: string; error?: AuthError | null }
+  | { type: 'RESET_PASSWORD'; email: string; error?: AuthError | null }
+  | {
+      type: 'REFRESH_SESSION';
+      session: Session | null;
+      error?: AuthError | null;
+    }
+  | {
+      type: 'UPDATE_USER';
+      attributes: UserAttributes;
+      error?: AuthError | null;
+    }
+  | { type: 'SIGN_OUT'; error?: AuthError | null };
 
 export type AuthDispatch = React.Dispatch<AuthContextAction>;
 
@@ -33,6 +55,7 @@ export interface AuthState {
   session: Session | null;
   user: User | null;
   isLoading: boolean;
+  error: Error | null;
   dispatch: AuthDispatch;
 }
 
@@ -47,13 +70,33 @@ export const useAuthReducer = () =>
         case 'VERIFY_OTP':
         case 'RESEND_VERIFICATION':
         case 'RESET_PASSWORD':
-          return { ...prevState, isLoading: false };
         case 'UPDATE_USER':
-          return { ...prevState, isLoading: false };
+          return {
+            ...prevState,
+            isLoading: false,
+            error: action.error ?? null,
+          };
         case 'SIGN_OUT':
-          return { ...prevState, user: null, session: null, isLoading: false };
+          return {
+            ...prevState,
+            user: null,
+            session: null,
+            isLoading: false,
+            error: action.error ?? null,
+          };
+        case 'REFRESH_SESSION':
+          return {
+            ...prevState,
+            session: action.session,
+            user: action.session ? action.session?.user : null,
+            isLoading: false,
+            error: action.error ?? null,
+          };
         case 'LOADING':
+          console.log('loading');
           return { ...prevState, isLoading: true };
+        case 'CLEAR_ERROR':
+          return { ...prevState, error: null };
         default:
           return prevState;
       }
@@ -62,6 +105,7 @@ export const useAuthReducer = () =>
       session: null,
       isLoading: false,
       user: null,
+      error: null,
       dispatch: () => null,
     },
   );
@@ -85,23 +129,18 @@ export function AuthContextProvider({
   children: React.ReactNode;
 }) {
   const [authState, dispatch] = useAuthReducer();
-  const [session, setSession] = useState<Session | null>(null);
-  const [user, setUser] = useState<User | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    supabase.auth
-      .getSession()
-      .then(({ data: { session: newSession } }) => {
-        setSession(newSession);
-        setUser(newSession ? newSession.user : null);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
+    console.log(`New auth session: ${JSON.stringify(authState)}`);
+  }, [authState]);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session: newSession } }) => {
+      dispatch({ type: 'REFRESH_SESSION', session: newSession });
+    });
 
     supabase.auth.onAuthStateChange((_event, newSession) => {
-      setSession(newSession);
+      dispatch({ type: 'REFRESH_SESSION', session: newSession });
     });
   }, []);
 
@@ -110,69 +149,70 @@ export function AuthContextProvider({
       dispatch({ type: 'LOADING' });
       switch (action.type) {
         case 'SIGN_UP':
-          signUp(action.email, action.password).then(() => dispatch(action));
+          signUp(action.email, action.password).then(({ error }) =>
+            dispatch({ ...action, error }),
+          );
           break;
         case 'SIGN_IN_WITH_EMAIL':
-          signInWithEmail(action.email, action.password).then(() =>
-            dispatch(action),
+          signInWithEmail(action.email, action.password).then(({ error }) =>
+            dispatch({ ...action, error }),
           );
           break;
         case 'VERIFY_OTP':
-          verifyOtp(action.email, action.token).then(() => dispatch(action));
+          verifyOtp(action.email, action.token).then(({ error }) =>
+            dispatch({ ...action, error }),
+          );
           break;
         case 'RESEND_VERIFICATION':
-          resendVerification(action.email).then(() => dispatch(action));
+          resendVerification(action.email).then(({ error }) =>
+            dispatch({ ...action, error }),
+          );
           break;
         case 'RESET_PASSWORD':
-          resetPassword(action.email).then(() => dispatch(action));
+          resetPassword(action.email).then(({ error }) =>
+            dispatch({ ...action, error }),
+          );
           break;
         case 'UPDATE_USER':
-          updateUser(action.attributes).then(() => dispatch(action));
+          updateUser(action.attributes).then(({ error }) =>
+            dispatch({ ...action, error }),
+          );
           break;
         case 'SIGN_OUT':
-          signOut().then(() => dispatch(action));
+          signOut().then(({ error }) => dispatch({ ...action, error }));
           break;
+        case 'REFRESH_SESSION':
+        case 'CLEAR_ERROR':
         default:
           return dispatch(action);
       }
     };
   }
 
-  const signInWithEmail = async (email: string, password: string) => {
-    const value = await supabase.auth.signInWithPassword({
+  const signInWithEmail = async (email: string, password: string) =>
+    await supabase.auth.signInWithPassword({
       email,
       password,
     });
-
-    setUser(value.data.user);
-    return value;
-  };
 
   const signUp = async (email: string, password: string) => {
     const value = await supabase.auth.signUp({
       email,
       password,
-    }); // will trigger the use effect to update the session
-
+    });
     console.log(value);
-    setUser(value.data.user);
+
     return value;
   };
 
-  const signOut = async () => {
-    await supabase.auth.signOut();
-  };
+  const signOut = async () => await supabase.auth.signOut();
 
-  const verifyOtp = async (email: string, token: string) => {
-    const value = await supabase.auth.verifyOtp({
+  const verifyOtp = async (email: string, token: string) =>
+    await supabase.auth.verifyOtp({
       email,
       token,
       type: 'email',
     });
-
-    // if (value.data.user) setUser(value.data.user);
-    return value;
-  };
 
   const resendVerification = async (email: string) =>
     await supabase.auth.resend({
@@ -183,22 +223,15 @@ export function AuthContextProvider({
   const resetPassword = async (email: string) =>
     await supabase.auth.resetPasswordForEmail(email);
 
-  const updateUser = async (attributes: UserAttributes) => {
-    const {
-      data: { user },
-    } = await supabase.auth.updateUser(attributes);
-
-    setUser(user);
-  };
+  const updateUser = async (attributes: UserAttributes) =>
+    await supabase.auth.updateUser(attributes);
 
   const authContextValue = useMemo(
     () => ({
-      user,
-      session,
-      isLoading,
+      ...authState,
       dispatch: dispatchMiddleware(dispatch),
     }),
-    [session, user, isLoading],
+    [authState],
   );
 
   return (

--- a/src/utils/AuthContext.tsx
+++ b/src/utils/AuthContext.tsx
@@ -16,7 +16,6 @@ import supabase from './supabase';
 
 type AuthContextAction =
   | { type: 'LOADING' }
-  | { type: 'CLEAR_ERROR' }
   | { type: 'SIGN_UP' }
   | { type: 'SIGN_IN_WITH_EMAIL' }
   | { type: 'VERIFY_OTP' }
@@ -30,7 +29,7 @@ export type AuthDispatch = React.Dispatch<AuthContextAction>;
 
 export interface AuthState {
   session: Session | null;
-  user: User | null;
+  userProfile: User | null;
   isLoading: boolean;
   dispatch: AuthDispatch;
 }
@@ -54,7 +53,7 @@ export const useAuthReducer = () =>
         case 'SIGN_OUT':
           return {
             ...prevState,
-            user: null,
+            userProfile: null,
             session: null,
             isLoading: false,
           };
@@ -62,14 +61,12 @@ export const useAuthReducer = () =>
           return {
             ...prevState,
             session: action.session,
-            user: action.session ? action.session?.user : null,
+            userProfile: action.session ? action.session?.user : null,
             isLoading: false,
           };
         case 'LOADING':
           console.log('loading');
           return { ...prevState, isLoading: true };
-        case 'CLEAR_ERROR':
-          return { ...prevState, error: null };
         default:
           return prevState;
       }
@@ -77,7 +74,7 @@ export const useAuthReducer = () =>
     {
       session: null,
       isLoading: false,
-      user: null,
+      userProfile: null,
       dispatch: () => null,
     },
   );
@@ -103,15 +100,14 @@ export function AuthContextProvider({
   const [authState, dispatch] = useAuthReducer();
 
   useEffect(() => {
-    console.log(`New auth session: ${JSON.stringify(authState)}`);
-  }, [authState]);
-
-  useEffect(() => {
     supabase.auth.getSession().then(({ data: { session: newSession } }) => {
+      console.log('callback');
+
       dispatch({ type: 'REFRESH_SESSION', session: newSession });
     });
 
     supabase.auth.onAuthStateChange((_event, newSession) => {
+      console.log('callback');
       dispatch({ type: 'REFRESH_SESSION', session: newSession });
     });
   }, []);

--- a/src/utils/AuthContext.tsx
+++ b/src/utils/AuthContext.tsx
@@ -107,6 +107,7 @@ export function AuthContextProvider({
 
   function dispatchMiddleware(dispatch: AuthDispatch) {
     return (action: AuthContextAction) => {
+      dispatch({ type: 'LOADING' });
       switch (action.type) {
         case 'SIGN_UP':
           signUp(action.email, action.password).then(() => dispatch(action));


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR

- Uses `useReducer` to manage the auth state of the app
- Creates auth.tsx to hold functions that can change the auth state and do auth actions

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links

https://github.com/calblueprint/chinese-newcomers/blob/6c86c6fe878f0fecb4b98ab417e8df18cba53e5a/src/context/AuthContext.tsx#L22

### Notion Sprint Task

https://www.notion.so/calblueprint/auth-Implement-useReducer-to-organize-AuthContext-functions-f540a909c0ed44eeada8ec7fd7467042?pvs=4

[//]: # 'Add the relevant Notion link(s) here'

### Online sources

None

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## How to review

- Log in with an existing account
- Try changing password with an existing account
- Since sign up only works on a newer version of the app it can't be tested here. But, those files weren't changed except for the imports to the new functions in auth.tsx instead of from the useSession hook. Since the logic stayed the same, I think its safe to assume they still work.

[//]: # 'The order in which to review files and what to expect when testing locally'

## Next steps

None

## Tests Performed, Edge Cases

See how to review

### Screenshots

N/A

CC: @akshaynthakur

[//]: # 'This tags in Akshay as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
