### PR TITLE
[search] Implement recent searches

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,6 +17,7 @@
       "supportsTablet": true
     },
     "android": {
+      "softwareKeyboardLayoutMode": "pan",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mui/material": "^5.14.13",
         "@mui/styled-engine-sc": "^6.0.0-alpha.1",
         "@mui/system": "^5.14.13",
-        "@react-native-async-storage/async-storage": "1.18.2",
+        "@react-native-async-storage/async-storage": "^1.18.2",
         "@react-native-community/datetimepicker": "7.2.0",
         "@react-navigation/bottom-tabs": "^6.5.9",
         "@react-navigation/material-bottom-tabs": "^6.2.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "react-native-screens": "~3.22.0",
         "react-native-svg": "13.9.0",
         "react-native-url-polyfill": "^2.0.0",
-        "react-native-vector-icons": "^10.0.0",
+        "react-native-vector-icons": "^10.0.2",
         "react-scroll-to-top": "^3.0.0"
       },
       "devDependencies": {
@@ -16420,9 +16420,9 @@
       }
     },
     "node_modules/react-native-vector-icons": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.0.0.tgz",
-      "integrity": "sha512-efMOVbZIebY8RszZPzPBoXi9pvD/NFYmjIDYxRoc9LYSzV8rMJtT8FfcO2hPu85Rn2x9xktha0+qn0B7EqMAcQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.0.2.tgz",
+      "integrity": "sha512-ZwhUkJhIMkGL3cW7IT4sEEHu2AOzerqsRQ73UzXsB+ecBpVK5bRmp0XswiQleZKZalZfs/WIfWLXLfTQHcQo6A==",
       "dependencies": {
         "prop-types": "^15.7.2",
         "yargs": "^16.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mui/material": "^5.14.13",
         "@mui/styled-engine-sc": "^6.0.0-alpha.1",
         "@mui/system": "^5.14.13",
-        "@react-native-async-storage/async-storage": "^1.18.2",
+        "@react-native-async-storage/async-storage": "^1.19.5",
         "@react-native-community/datetimepicker": "7.2.0",
         "@react-navigation/bottom-tabs": "^6.5.9",
         "@react-navigation/material-bottom-tabs": "^6.2.17",
@@ -4767,9 +4767,9 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.18.2.tgz",
-      "integrity": "sha512-dM8AfdoeIxlh+zqgr0o5+vCTPQ0Ru1mrPzONZMsr7ufp5h+6WgNxQNza7t0r5qQ6b04AJqTlBNixTWZxqP649Q==",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.19.5.tgz",
+      "integrity": "sha512-zLT7oNPXpW8BxJyHyq8AJbXtlHE/eonFWuJt44y0WeCGnp4KOJ8mfqD8mtAIKLyrYHHE1uadFe/s4C+diYAi8g==",
       "dependencies": {
         "merge-options": "^3.0.4"
       },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mui/material": "^5.14.13",
     "@mui/styled-engine-sc": "^6.0.0-alpha.1",
     "@mui/system": "^5.14.13",
-    "@react-native-async-storage/async-storage": "1.18.2",
+    "@react-native-async-storage/async-storage": "^1.18.2",
     "@react-native-community/datetimepicker": "7.2.0",
     "@react-navigation/bottom-tabs": "^6.5.9",
     "@react-navigation/material-bottom-tabs": "^6.2.17",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mui/material": "^5.14.13",
     "@mui/styled-engine-sc": "^6.0.0-alpha.1",
     "@mui/system": "^5.14.13",
-    "@react-native-async-storage/async-storage": "^1.19.5",
+    "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/datetimepicker": "7.2.0",
     "@react-navigation/bottom-tabs": "^6.5.9",
     "@react-navigation/material-bottom-tabs": "^6.2.17",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@mui/material": "^5.14.13",
     "@mui/styled-engine-sc": "^6.0.0-alpha.1",
     "@mui/system": "^5.14.13",
-    "@react-native-async-storage/async-storage": "^1.18.2",
+    "@react-native-async-storage/async-storage": "^1.19.5",
     "@react-native-community/datetimepicker": "7.2.0",
     "@react-navigation/bottom-tabs": "^6.5.9",
     "@react-navigation/material-bottom-tabs": "^6.2.17",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-native-screens": "~3.22.0",
     "react-native-svg": "13.9.0",
     "react-native-url-polyfill": "^2.0.0",
-    "react-native-vector-icons": "^10.0.0",
+    "react-native-vector-icons": "^10.0.2",
     "react-scroll-to-top": "^3.0.0"
   },
   "devDependencies": {

--- a/src/app/(tabs)/home/index.tsx
+++ b/src/app/(tabs)/home/index.tsx
@@ -7,6 +7,7 @@ import styles from './styles';
 import Icon from '../../../../assets/icons';
 import ContentCard from '../../../components/ContentCard/ContentCard';
 import PreviewCard from '../../../components/PreviewCard/PreviewCard';
+import RecentSearchCard from '../../../components/RecentSearchCard/RecentSearchCard';
 import { fetchUsername } from '../../../queries/profiles';
 import {
   fetchFeaturedStoriesDescription,

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -93,11 +93,15 @@ function SearchScreen() {
       setRecentSearches(await getRecentSearch());
     })();
 
+    // Testing to see if we can getRecentSearches() from Async Storage
     (async () => {
-      setRecentSearches(await getRecentSearch());
+      // setRecentSearches(await getRecentSearch());
+      console.log(getRecentSearch());
     })();
   }, []);
 
+  // UseEffect upon change of recentSearches (Set)
+  // EVENTUALLY FIX TO WHERE IT DOES IT BEFORE EXITING PAGE RATHER THAN EVERY ALTERATION OF SET (LIKE THIS FOR TESTING RN)
   useEffect(() => {
     setRecentSearch(recentSearches);
   }, [focus]);

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -64,6 +64,10 @@ function SearchScreen() {
     })();
   }, []);
 
+  useEffect(() => {
+    setRecentSearch(recentSearches);
+  }, [recentSearches]); // fix this useEffect
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={[filterVisible ? styles.greyOverlay : styles.noOverlay]} />
@@ -83,12 +87,17 @@ function SearchScreen() {
         value={search}
         onSubmitEditing={searchString => {
           const result: RecentSearch = {
-            value: searchString.toString(),
-            numResults: searchResults.length,
+            value: searchString.nativeEvent.text, // works
+            numResults: searchResults.length, // works
           };
+
           setRecentSearches(
-            previousState => new Set([...previousState, result]),
+            // new Set<RecentSearch>([...recentSearches, result]),
+            previousSet => new Set<RecentSearch>(previousSet).add(result),
+            // previousSet => new Set<RecentSearch>([...previousSet, result]),
+            // previousSet => new Set<RecentSearch>(previousSet ? [...previousSet, result] : [result]), // getting that previousSet is null
           );
+          // console.log(recentSearches);
         }}
       />
       <Button

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -8,7 +8,7 @@ import styles from './styles';
 import FilterModal from '../../../components/FilterModal/FilterModal';
 import SearchCard from '../../../components/PreviewCard/PreviewCard';
 import { fetchAllStoryPreviews } from '../../../queries/stories';
-import { StoryPreview } from '../../../queries/types';
+import { StoryPreview, RecentSearch } from '../../../queries/types';
 import globalStyles from '../../../styles/globalStyles';
 
 function SearchScreen() {
@@ -16,6 +16,7 @@ function SearchScreen() {
   const [searchResults, setSearchResults] = useState<StoryPreview[]>([]);
   const [search, setSearch] = useState('');
   const [filterVisible, setFilterVisible] = useState(false);
+  const [recentSearches, setRecentSearches] = useState(Set<RecentSearch>);
 
   const searchFunction = (text: string) => {
     if (text === '') {

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -82,7 +82,7 @@ function SearchScreen() {
     (async () => {
       setRecentSearches(await getRecentSearch());
     })();
-  }, [recentSearches]); // fix this useEffect
+  }, [recentSearches]); // fix this useEffect to be when it switches page
 
   return (
     <SafeAreaView style={styles.container}>

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -8,7 +8,7 @@ import styles from './styles';
 import FilterModal from '../../../components/FilterModal/FilterModal';
 import SearchCard from '../../../components/SearchCard/SearchCard';
 import { fetchAllStoryPreviews } from '../../../queries/stories';
-import { StoryPreview } from '../../../queries/types';
+import { StoryPreview, RecentSearch } from '../../../queries/types';
 import globalStyles from '../../../styles/globalStyles';
 
 function SearchScreen() {
@@ -16,6 +16,7 @@ function SearchScreen() {
   const [searchResults, setSearchResults] = useState<StoryPreview[]>([]);
   const [search, setSearch] = useState('');
   const [filterVisible, setFilterVisible] = useState(false);
+  const [recentSearches, setRecentSearches] = useState(Set<RecentSearch>);
 
   const searchFunction = (text: string) => {
     if (text === '') {

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -92,12 +92,6 @@ function SearchScreen() {
 
       setRecentSearches(await getRecentSearch());
     })();
-
-    // Testing to see if we can getRecentSearches() from Async Storage
-    (async () => {
-      // setRecentSearches(await getRecentSearch());
-      console.log(getRecentSearch());
-    })();
   }, []);
 
   // UseEffect upon change of recentSearches (Set)

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -68,18 +68,17 @@ function SearchScreen() {
   // Gets the recentSearches (Set) from Async Storage
   const getRecentSearch = async () => {
     try {
-      const jsonValue = await AsyncStorage.getItem('GWN_RECENT_SEARCHES_ARRAY');
-      return jsonValue != null ? JSON.parse(jsonValue) : [];
+      const jsonValue = await AsyncStorage.getItem(key);
+      return jsonValue != null ? JSON.parse(jsonValue) : null;
     } catch (error) {
       console.log(error); // error reading value
     }
   };
 
-  // Sets the Async Storage to recentSearches (Set)
-  const setRecentSearch = async (recentSearchesArray: RecentSearch[]) => {
+  const setRecentSearch = async (searchResult: RecentSearch) => {
     try {
-      const jsonValue = JSON.stringify(recentSearchesArray);
-      await AsyncStorage.setItem('GWN_RECENT_SEARCHES_ARRAY', jsonValue);
+      const jsonValue = JSON.stringify(searchResult);
+      await AsyncStorage.setItem('my-key', jsonValue);
     } catch (error) {
       console.log(error); // saving error
     }
@@ -91,6 +90,10 @@ function SearchScreen() {
       const data: StoryPreview[] = await fetchAllStoryPreviews();
       setAllStories(data);
 
+      setRecentSearches(await getRecentSearch());
+    })();
+
+    (async () => {
       setRecentSearches(await getRecentSearch());
     })();
   }, []);
@@ -116,9 +119,6 @@ function SearchScreen() {
         placeholderTextColor="black"
         onChangeText={text => searchFunction(text)}
         value={search}
-        onSubmitEditing={searchString => {
-          searchResultStacking(searchString.nativeEvent.text);
-        }}
       />
       <Button
         title="Show Filter Modal"

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -10,6 +10,7 @@ import SearchCard from '../../../components/SearchCard/SearchCard';
 import { fetchAllStoryPreviews } from '../../../queries/stories';
 import { StoryPreview, RecentSearch } from '../../../queries/types';
 import globalStyles from '../../../styles/globalStyles';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 function SearchScreen() {
   const [allStories, setAllStories] = useState<StoryPreview[]>([]);
@@ -32,6 +33,24 @@ function SearchScreen() {
     });
     setSearch(text);
     setSearchResults(updatedData);
+  };
+
+  const getRecentSearch = async (searchResult: RecentSearch) => {
+    try {
+      const jsonValue = await AsyncStorage.getItem('my-key'); // change the key
+      return jsonValue != null ? JSON.parse(jsonValue) : null;
+    } catch (e) {
+      // error reading value
+    }
+  };
+
+  const setRecentSearch = async (searchResult: RecentSearch) => {
+    try {
+      const jsonValue = JSON.stringify(searchResult);
+      await AsyncStorage.setItem('my-key', jsonValue);
+    } catch (e) {
+      // saving error
+    }
   };
 
   useEffect(() => {

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -94,8 +94,6 @@ function SearchScreen() {
     })();
   }, []);
 
-  // UseEffect upon change of recentSearches (Set)
-  // EVENTUALLY FIX TO WHERE IT DOES IT BEFORE EXITING PAGE RATHER THAN EVERY ALTERATION OF SET (LIKE THIS FOR TESTING RN)
   useEffect(() => {
     setRecentSearch(recentSearches);
   }, [focus]);

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -25,7 +25,7 @@ function SearchScreen() {
   const searchFunction = (text: string) => {
     if (text === '') {
       setSearch(text);
-      setSearchResults(allStories);
+      setSearchResults([]);
       return;
     }
     const updatedData = allStories.filter((item: StoryPreview) => {
@@ -124,13 +124,13 @@ function SearchScreen() {
         onPress={() => setFilterVisible(true)}
       />
       {search ? (
-        <Text>Showing Results {searchResults.length}</Text>
+        <Text style={styles.searchText}>
+          Showing Results {searchResults.length}
+        </Text>
       ) : (
         <>
-          <View
-            style={{ justifyContent: 'space-between', flexDirection: 'row' }}
-          >
-            <Text>Recent Searches</Text>
+          <View style={styles.recentSpacing}>
+            <Text style={styles.searchText}>Recent Searches</Text>
             <Button
               onPress={clearRecentSearches}
               title="Clear All"
@@ -138,7 +138,6 @@ function SearchScreen() {
             />
           </View>
           <FlatList
-            style={{ paddingBottom: 200 }}
             showsVerticalScrollIndicator={false}
             data={recentSearches}
             renderItem={({ item }) => (

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SearchBar } from '@rneui/themed';
 import { Link, router } from 'expo-router';
 import React, { useEffect, useState } from 'react';
@@ -10,14 +11,13 @@ import SearchCard from '../../../components/PreviewCard/PreviewCard';
 import { fetchAllStoryPreviews } from '../../../queries/stories';
 import { StoryPreview, RecentSearch } from '../../../queries/types';
 import globalStyles from '../../../styles/globalStyles';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 
 function SearchScreen() {
   const [allStories, setAllStories] = useState<StoryPreview[]>([]);
   const [searchResults, setSearchResults] = useState<StoryPreview[]>([]);
   const [search, setSearch] = useState('');
   const [filterVisible, setFilterVisible] = useState(false);
-  const [recentSearches, setRecentSearches] = useState(Set<RecentSearch>);
+  const [recentSearches, setRecentSearches] = useState(new Set<RecentSearch>());
 
   const searchFunction = (text: string) => {
     if (text === '') {
@@ -35,12 +35,12 @@ function SearchScreen() {
     setSearchResults(updatedData);
   };
 
-  const getRecentSearch = async (searchResult: RecentSearch) => {
+  const getRecentSearch = async (key: string) => {
     try {
-      const jsonValue = await AsyncStorage.getItem('my-key'); // change the key
+      const jsonValue = await AsyncStorage.getItem(key);
       return jsonValue != null ? JSON.parse(jsonValue) : null;
-    } catch (e) {
-      // error reading value
+    } catch (error) {
+      console.log(error); // error reading value
     }
   };
 
@@ -48,8 +48,8 @@ function SearchScreen() {
     try {
       const jsonValue = JSON.stringify(searchResult);
       await AsyncStorage.setItem('my-key', jsonValue);
-    } catch (e) {
-      // saving error
+    } catch (error) {
+      console.log(error); // saving error
     }
   };
 

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -68,17 +68,17 @@ function SearchScreen() {
   // Gets the recentSearches (Set) from Async Storage
   const getRecentSearch = async () => {
     try {
-      const jsonValue = await AsyncStorage.getItem(key);
+      const jsonValue = await AsyncStorage.getItem('GWN_RECENT_SEARCHES_ARRAY');
       return jsonValue != null ? JSON.parse(jsonValue) : null;
     } catch (error) {
       console.log(error); // error reading value
     }
   };
 
-  const setRecentSearch = async (searchResult: RecentSearch) => {
+  const setRecentSearch = async (searchResult: RecentSearch[]) => {
     try {
       const jsonValue = JSON.stringify(searchResult);
-      await AsyncStorage.setItem('my-key', jsonValue);
+      await AsyncStorage.setItem('GWN_RECENT_SEARCHES_ARRAY', jsonValue);
     } catch (error) {
       console.log(error); // saving error
     }

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -3,12 +3,13 @@ import { useIsFocused } from '@react-navigation/native';
 import { SearchBar } from '@rneui/themed';
 import { Link, router } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { Button, FlatList, View } from 'react-native';
+import { Button, FlatList, View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import styles from './styles';
 import FilterModal from '../../../components/FilterModal/FilterModal';
 import SearchCard from '../../../components/PreviewCard/PreviewCard';
+import RecentSearchCard from '../../../components/RecentSearchCard/RecentSearchCard';
 import { fetchAllStoryPreviews } from '../../../queries/stories';
 import { StoryPreview, RecentSearch } from '../../../queries/types';
 import globalStyles from '../../../styles/globalStyles';
@@ -37,11 +38,37 @@ function SearchScreen() {
     setSearchResults(updatedData);
   };
 
+  const clearRecentSearches = () => {
+    setRecentSearches([]);
+    setRecentSearch([]);
+  };
+
+  const searchResultStacking = (searchString: string) => {
+    if (searchString !== '') {
+      const maxArrayLength = 5;
+      setRecentSearches(recentSearches.reverse());
+      for (let i = 0; i < recentSearches.length; i++) {
+        if (searchString === recentSearches[i].value) {
+          setRecentSearches(recentSearches.splice(i, 1));
+          break;
+        }
+      }
+      if (recentSearches.length >= maxArrayLength) {
+        setRecentSearches(recentSearches.splice(0, 1));
+      }
+
+      const result: RecentSearch = {
+        value: searchString,
+        numResults: searchResults.length,
+      };
+      setRecentSearches(recentSearches.concat(result).reverse());
+    }
+  };
+
   // Gets the recentSearches (Set) from Async Storage
   const getRecentSearch = async () => {
     try {
-      const jsonValue = await AsyncStorage.getItem('1'); //'GWN_RECENT_SEARCHES_ARRAY');
-      console.log('\nGetting AsyncStorage: ' + jsonValue);
+      const jsonValue = await AsyncStorage.getItem('GWN_RECENT_SEARCHES_ARRAY');
       return jsonValue != null ? JSON.parse(jsonValue) : [];
     } catch (error) {
       console.log(error); // error reading value
@@ -52,8 +79,7 @@ function SearchScreen() {
   const setRecentSearch = async (recentSearchesArray: RecentSearch[]) => {
     try {
       const jsonValue = JSON.stringify(recentSearchesArray);
-      console.log('\nSetting AsyncStorage: ' + jsonValue);
-      await AsyncStorage.setItem('1', jsonValue); // 'GWN_RECENT_SEARCHES_ARRAY', jsonValue);
+      await AsyncStorage.setItem('GWN_RECENT_SEARCHES_ARRAY', jsonValue);
     } catch (error) {
       console.log(error); // saving error
     }
@@ -69,12 +95,9 @@ function SearchScreen() {
     })();
   }, []);
 
-  // UseEffect upon change of recentSearches (Set)
-  // EVENTUALLY FIX TO WHERE IT DOES IT BEFORE EXITING PAGE RATHER THAN EVERY ALTERATION OF SET (LIKE THIS FOR TESTING RN)
   useEffect(() => {
     setRecentSearch(recentSearches);
-    console.log('');
-  }, [focus]); // fix this useEffect to be when it switches page
+  }, [focus]);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -94,18 +117,42 @@ function SearchScreen() {
         onChangeText={text => searchFunction(text)}
         value={search}
         onSubmitEditing={searchString => {
-          const result: RecentSearch = {
-            value: searchString.nativeEvent.text, // works
-            numResults: searchResults.length, // works
-          };
-
-          setRecentSearches(recentSearches.concat(result));
+          searchResultStacking(searchString.nativeEvent.text);
         }}
       />
       <Button
         title="Show Filter Modal"
         onPress={() => setFilterVisible(true)}
       />
+      {search ? (
+        <Text>Showing Results {searchResults.length}</Text>
+      ) : (
+        <>
+          <View
+            style={{ justifyContent: 'space-between', flexDirection: 'row' }}
+          >
+            <Text>Recent Searches</Text>
+            <Button
+              onPress={clearRecentSearches}
+              title="Clear All"
+              color="#EB563B"
+            />
+          </View>
+          <FlatList
+            style={{ paddingBottom: 200 }}
+            showsVerticalScrollIndicator={false}
+            data={recentSearches}
+            renderItem={({ item }) => (
+              <RecentSearchCard
+                key={item.value}
+                value={item.value}
+                numResults={item.numResults}
+                pressFunction={() => null} // add functionality for each recentSearch
+              />
+            )}
+          />
+        </>
+      )}
       <FlatList
         showsVerticalScrollIndicator={false}
         data={searchResults}

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SearchBar } from '@rneui/themed';
 import { Link, router } from 'expo-router';
 import React, { useEffect, useState } from 'react';
@@ -10,14 +11,13 @@ import SearchCard from '../../../components/SearchCard/SearchCard';
 import { fetchAllStoryPreviews } from '../../../queries/stories';
 import { StoryPreview, RecentSearch } from '../../../queries/types';
 import globalStyles from '../../../styles/globalStyles';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 
 function SearchScreen() {
   const [allStories, setAllStories] = useState<StoryPreview[]>([]);
   const [searchResults, setSearchResults] = useState<StoryPreview[]>([]);
   const [search, setSearch] = useState('');
   const [filterVisible, setFilterVisible] = useState(false);
-  const [recentSearches, setRecentSearches] = useState(Set<RecentSearch>);
+  const [recentSearches, setRecentSearches] = useState(new Set<RecentSearch>());
 
   const searchFunction = (text: string) => {
     if (text === '') {
@@ -35,12 +35,12 @@ function SearchScreen() {
     setSearchResults(updatedData);
   };
 
-  const getRecentSearch = async (searchResult: RecentSearch) => {
+  const getRecentSearch = async (key: string) => {
     try {
-      const jsonValue = await AsyncStorage.getItem('my-key'); // change the key
+      const jsonValue = await AsyncStorage.getItem(key);
       return jsonValue != null ? JSON.parse(jsonValue) : null;
-    } catch (e) {
-      // error reading value
+    } catch (error) {
+      console.log(error); // error reading value
     }
   };
 
@@ -48,8 +48,8 @@ function SearchScreen() {
     try {
       const jsonValue = JSON.stringify(searchResult);
       await AsyncStorage.setItem('my-key', jsonValue);
-    } catch (e) {
-      // saving error
+    } catch (error) {
+      console.log(error); // saving error
     }
   };
 

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -35,19 +35,19 @@ function SearchScreen() {
     setSearchResults(updatedData);
   };
 
-  const getRecentSearch = async (key: string) => {
+  const getRecentSearch = async () => {
     try {
-      const jsonValue = await AsyncStorage.getItem(key);
+      const jsonValue = await AsyncStorage.getItem('GWN_RECENT_SEARCHES');
       return jsonValue != null ? JSON.parse(jsonValue) : null;
     } catch (error) {
       console.log(error); // error reading value
     }
   };
 
-  const setRecentSearch = async (searchResult: RecentSearch) => {
+  const setRecentSearch = async (recentSearchesSet: Set<RecentSearch>) => {
     try {
-      const jsonValue = JSON.stringify(searchResult);
-      await AsyncStorage.setItem('my-key', jsonValue);
+      const jsonValue = JSON.stringify(recentSearchesSet);
+      await AsyncStorage.setItem('GWN_RECENT_SEARCHES', jsonValue);
     } catch (error) {
       console.log(error); // saving error
     }
@@ -57,6 +57,10 @@ function SearchScreen() {
     (async () => {
       const data: StoryPreview[] = await fetchAllStoryPreviews();
       setAllStories(data);
+    })();
+
+    (async () => {
+      setRecentSearches(await getRecentSearch());
     })();
   }, []);
 
@@ -73,11 +77,19 @@ function SearchScreen() {
         leftIconContainerStyle={{}}
         rightIconContainerStyle={{}}
         lightTheme
-        loadingProps={{}}
         placeholder="Search"
         placeholderTextColor="black"
         onChangeText={text => searchFunction(text)}
         value={search}
+        onSubmitEditing={searchString => {
+          const result: RecentSearch = {
+            value: searchString.toString(),
+            numResults: searchResults.length,
+          };
+          setRecentSearches(
+            previousState => new Set([...previousState, result]),
+          );
+        }}
       />
       <Button
         title="Show Filter Modal"

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -35,15 +35,19 @@ function SearchScreen() {
     setSearchResults(updatedData);
   };
 
+  // Gets the recentSearches (Set) from Async Storage
   const getRecentSearch = async () => {
     try {
       const jsonValue = await AsyncStorage.getItem('GWN_RECENT_SEARCHES');
-      return jsonValue != null ? JSON.parse(jsonValue) : null;
+      return jsonValue != null
+        ? JSON.parse(jsonValue)
+        : new Set<RecentSearch>();
     } catch (error) {
       console.log(error); // error reading value
     }
   };
 
+  // Sets the Async Storage to recentSearches (Set)
   const setRecentSearch = async (recentSearchesSet: Set<RecentSearch>) => {
     try {
       const jsonValue = JSON.stringify(recentSearchesSet);
@@ -53,19 +57,31 @@ function SearchScreen() {
     }
   };
 
+  // UseEffect upon first rendering
   useEffect(() => {
     (async () => {
       const data: StoryPreview[] = await fetchAllStoryPreviews();
       setAllStories(data);
     })();
 
+    // Testing to see if we can getRecentSearches() from Async Storage
     (async () => {
-      setRecentSearches(await getRecentSearch());
+      // setRecentSearches(await getRecentSearch());
+      console.log(getRecentSearch());
     })();
   }, []);
 
+  // UseEffect upon change of recentSearches (Set)
+  // EVENTUALLY FIX TO WHERE IT DOES IT BEFORE EXITING PAGE RATHER THAN EVERY ALTERATION OF SET (LIKE THIS FOR TESTING RN)
   useEffect(() => {
     setRecentSearch(recentSearches);
+
+    // testing funcion getRecentSearch
+    // (maybe check for null when first getting asyncStorage cuz it might be empty)
+    // DELETE AFTER BUG FIXED
+    (async () => {
+      setRecentSearches(await getRecentSearch());
+    })();
   }, [recentSearches]); // fix this useEffect
 
   return (
@@ -92,12 +108,8 @@ function SearchScreen() {
           };
 
           setRecentSearches(
-            // new Set<RecentSearch>([...recentSearches, result]),
-            previousSet => new Set<RecentSearch>(previousSet).add(result),
-            // previousSet => new Set<RecentSearch>([...previousSet, result]),
-            // previousSet => new Set<RecentSearch>(previousSet ? [...previousSet, result] : [result]), // getting that previousSet is null
+            previousSet => new Set<RecentSearch>([...previousSet, result]),
           );
-          // console.log(recentSearches);
         }}
       />
       <Button

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -10,6 +10,7 @@ import SearchCard from '../../../components/PreviewCard/PreviewCard';
 import { fetchAllStoryPreviews } from '../../../queries/stories';
 import { StoryPreview, RecentSearch } from '../../../queries/types';
 import globalStyles from '../../../styles/globalStyles';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 function SearchScreen() {
   const [allStories, setAllStories] = useState<StoryPreview[]>([]);
@@ -32,6 +33,24 @@ function SearchScreen() {
     });
     setSearch(text);
     setSearchResults(updatedData);
+  };
+
+  const getRecentSearch = async (searchResult: RecentSearch) => {
+    try {
+      const jsonValue = await AsyncStorage.getItem('my-key'); // change the key
+      return jsonValue != null ? JSON.parse(jsonValue) : null;
+    } catch (e) {
+      // error reading value
+    }
+  };
+
+  const setRecentSearch = async (searchResult: RecentSearch) => {
+    try {
+      const jsonValue = JSON.stringify(searchResult);
+      await AsyncStorage.setItem('my-key', jsonValue);
+    } catch (e) {
+      // saving error
+    }
   };
 
   useEffect(() => {

--- a/src/app/(tabs)/search/styles.ts
+++ b/src/app/(tabs)/search/styles.ts
@@ -43,6 +43,16 @@ const styles = StyleSheet.create({
     width,
     height,
   },
+  recentSpacing: {
+    justifyContent: 'space-between',
+    flexDirection: 'row',
+    alignContent: 'space-between',
+  },
+  searchText: {
+    fontWeight: '300',
+    fontSize: 20,
+    paddingTop: 5,
+  },
 });
 
 export default styles;

--- a/src/app/(tabs)/search/styles.ts
+++ b/src/app/(tabs)/search/styles.ts
@@ -1,16 +1,17 @@
 import { Dimensions, StyleSheet } from 'react-native';
 
+import colors from '../../../styles/colors';
+
 const { width, height } = Dimensions.get('window');
 
 const styles = StyleSheet.create({
   container: {
+    width: '100%',
+    marginTop: 24,
     flex: 1,
-    backgroundColor: 'white',
-    justifyContent: 'flex-start',
-    paddingLeft: 24,
-    paddingRight: 24,
-    paddingTop: 20,
-    gap: 14,
+  },
+  default: {
+    marginHorizontal: 8,
   },
   searchContainer: {
     backgroundColor: 'transparent',
@@ -44,14 +45,32 @@ const styles = StyleSheet.create({
     height,
   },
   recentSpacing: {
-    justifyContent: 'space-between',
     flexDirection: 'row',
-    alignContent: 'space-between',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 0,
+    marginBottom: 8,
+    marginHorizontal: 8,
   },
   searchText: {
-    fontWeight: '300',
-    fontSize: 20,
-    paddingTop: 5,
+    fontWeight: '500',
+    fontSize: 14,
+  },
+  numDisplay: {
+    marginTop: 24,
+    marginBottom: 8,
+  },
+  clearAll: {
+    color: colors.gwnOrange,
+    fontSize: 12,
+    fontWeight: '400',
+  },
+  contentContainerRecents: {
+    paddingHorizontal: 8,
+  },
+  contentCotainerStories: {
+    paddingHorizontal: 8,
+    paddingBottom: 24,
   },
 });
 

--- a/src/components/PreviewCard/styles.ts
+++ b/src/components/PreviewCard/styles.ts
@@ -6,17 +6,15 @@ const styles = StyleSheet.create({
   card: {
     flexDirection: 'column',
     justifyContent: 'flex-end',
-    // alignItems: 'stretch',
     backgroundColor: colors.white,
     borderRadius: 6,
-    // height: 166,
-    // paddingLeft: 12,
-    // paddingRight: 12,
-    marginBottom: 16,
+    marginTop: 8,
+    marginBottom: 8,
     shadowColor: 'black',
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.5,
     elevation: 4,
+    paddingRight: 8,
   },
   top: {
     flex: 1,
@@ -36,7 +34,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     borderRadius: 6,
     paddingHorizontal: 12,
-    // paddingVertical: 12,
     paddingTop: 8,
   },
   image: {

--- a/src/components/RecentSearchCard/RecentSearchCard.tsx
+++ b/src/components/RecentSearchCard/RecentSearchCard.tsx
@@ -1,0 +1,33 @@
+import { GestureResponderEvent, Pressable, View, Text } from 'react-native';
+import Icon from 'react-native-vector-icons/AntDesign';
+
+import globalStyles from '../../styles/globalStyles';
+import React from 'react';
+import styles from './styles';
+
+type RecentSearchCardProps = {
+  value: string;
+  numResults: number;
+  pressFunction: (event: GestureResponderEvent) => void;
+};
+
+function RecentSearchCard({
+  value,
+  numResults,
+  pressFunction,
+}: RecentSearchCardProps) {
+  return (
+    <Pressable onPress={pressFunction}>
+      <View style={styles.card}>
+        <View style={styles.textContainer}>
+          <Icon name="search1" size={16} color="#A7A5A5" />
+          <Text style={styles.searchValueText}>{value}</Text>
+          <Text style={styles.numResultsText}>{numResults} Results</Text>
+          <Icon name="caretright" size={12} color="black" />
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+export default RecentSearchCard;

--- a/src/components/RecentSearchCard/RecentSearchCard.tsx
+++ b/src/components/RecentSearchCard/RecentSearchCard.tsx
@@ -19,10 +19,10 @@ function RecentSearchCard({
     <Pressable onPress={pressFunction}>
       <View style={styles.card}>
         <View style={styles.textContainer}>
-          <Icon name="search1" size={18} color="#A7A5A5" />
-          <Text>{value}</Text>
-          <Text>{numResults} Results</Text>
-          <Icon name="caretright" size={18} color="black" />
+          <Icon name="search1" size={16} color="#A7A5A5" />
+          <Text style={styles.searchValueText}>{value}</Text>
+          <Text style={styles.numResultsText}>{numResults} Results</Text>
+          <Icon name="caretright" size={12} color="black" />
         </View>
       </View>
     </Pressable>

--- a/src/components/RecentSearchCard/RecentSearchCard.tsx
+++ b/src/components/RecentSearchCard/RecentSearchCard.tsx
@@ -19,9 +19,11 @@ function RecentSearchCard({
   return (
     <Pressable onPress={pressFunction}>
       <View style={styles.card}>
-        <View style={styles.textContainer}>
+        <View style={styles.leftItems}>
           <Icon name="search1" size={16} color="#A7A5A5" />
           <Text style={styles.searchValueText}>{value}</Text>
+        </View>
+        <View style={styles.rightItems}>
           <Text style={styles.numResultsText}>{numResults} Results</Text>
           <Icon name="caretright" size={12} color="black" />
         </View>

--- a/src/components/RecentSearchCard/RecentSearchCard.tsx
+++ b/src/components/RecentSearchCard/RecentSearchCard.tsx
@@ -1,0 +1,32 @@
+import { GestureResponderEvent, Pressable, View, Text } from 'react-native';
+import Icon from 'react-native-vector-icons/AntDesign';
+
+import styles from './styles';
+import globalStyles from '../../styles/globalStyles';
+
+type RecentSearchCardProps = {
+  value: string;
+  numResults: number;
+  pressFunction: (event: GestureResponderEvent) => void;
+};
+
+function RecentSearchCard({
+  value,
+  numResults,
+  pressFunction,
+}: RecentSearchCardProps) {
+  return (
+    <Pressable onPress={pressFunction}>
+      <View style={styles.card}>
+        <View style={styles.textContainer}>
+          <Icon name="search1" size={18} color="#A7A5A5" />
+          <Text>{value}</Text>
+          <Text>{numResults} Results</Text>
+          <Icon name="caretright" size={18} color="black" />
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+export default RecentSearchCard;

--- a/src/components/RecentSearchCard/RecentSearchCard.tsx
+++ b/src/components/RecentSearchCard/RecentSearchCard.tsx
@@ -20,10 +20,10 @@ function RecentSearchCard({
     <Pressable onPress={pressFunction}>
       <View style={styles.card}>
         <View style={styles.textContainer}>
-          <Icon name="search1" size={18} color="#A7A5A5" />
-          <Text>{value}</Text>
-          <Text>{numResults} Results</Text>
-          <Icon name="caretright" size={18} color="black" />
+          <Icon name="search1" size={16} color="#A7A5A5" />
+          <Text style={styles.searchValueText}>{value}</Text>
+          <Text style={styles.numResultsText}>{numResults} Results</Text>
+          <Icon name="caretright" size={12} color="black" />
         </View>
       </View>
     </Pressable>

--- a/src/components/RecentSearchCard/RecentSearchCard.tsx
+++ b/src/components/RecentSearchCard/RecentSearchCard.tsx
@@ -1,9 +1,9 @@
+import React from 'react';
 import { GestureResponderEvent, Pressable, View, Text } from 'react-native';
 import Icon from 'react-native-vector-icons/AntDesign';
 
-import globalStyles from '../../styles/globalStyles';
-import React from 'react';
 import styles from './styles';
+import globalStyles from '../../styles/globalStyles';
 
 type RecentSearchCardProps = {
   value: string;
@@ -20,10 +20,10 @@ function RecentSearchCard({
     <Pressable onPress={pressFunction}>
       <View style={styles.card}>
         <View style={styles.textContainer}>
-          <Icon name="search1" size={16} color="#A7A5A5" />
-          <Text style={styles.searchValueText}>{value}</Text>
-          <Text style={styles.numResultsText}>{numResults} Results</Text>
-          <Icon name="caretright" size={12} color="black" />
+          <Icon name="search1" size={18} color="#A7A5A5" />
+          <Text>{value}</Text>
+          <Text>{numResults} Results</Text>
+          <Icon name="caretright" size={18} color="black" />
         </View>
       </View>
     </Pressable>

--- a/src/components/RecentSearchCard/styles.ts
+++ b/src/components/RecentSearchCard/styles.ts
@@ -13,10 +13,24 @@ const styles = StyleSheet.create({
     maxHeight: 100,
     paddingLeft: 12,
     paddingRight: 12,
+    paddingBottom: 4,
+    paddingTop: 4,
   },
   textContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+  },
+  searchValueText: {
+    color: 'black',
+    fontWeight: '400',
+    fontSize: 14,
+    justifyContent: 'center',
+  },
+  numResultsText: {
+    color: '#A7A5A5',
+    fontWeight: '400',
+    fontSize: 10,
+    justifyContent: 'center',
   },
 });
 

--- a/src/components/RecentSearchCard/styles.ts
+++ b/src/components/RecentSearchCard/styles.ts
@@ -9,7 +9,6 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     marginTop: 8,
     marginBottom: 8,
-    maxHeight: 100,
     paddingLeft: 12,
     paddingRight: 12,
     paddingBottom: 10,

--- a/src/components/RecentSearchCard/styles.ts
+++ b/src/components/RecentSearchCard/styles.ts
@@ -1,15 +1,23 @@
 import { StyleSheet } from 'react-native';
 
-export default StyleSheet.create({
+import colors from '../../styles/colors';
+
+const styles = StyleSheet.create({
   card: {
-    flex: 1,
-    backgroundColor: 'white',
-    alignItems: 'flex-start',
+    flexDirection: 'row',
     justifyContent: 'flex-start',
-    paddingLeft: 24,
-    paddingRight: 24,
+    alignItems: 'center',
+    backgroundColor: colors.lightGrey,
+    borderRadius: 4,
+    marginBottom: 16,
+    maxHeight: 100,
+    paddingLeft: 12,
+    paddingRight: 12,
   },
-  textContainer: {},
-  searchValueText: {},
-  numResultsText: {},
+  textContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
 });
+
+export default styles;

--- a/src/components/RecentSearchCard/styles.ts
+++ b/src/components/RecentSearchCard/styles.ts
@@ -1,0 +1,23 @@
+import { StyleSheet } from 'react-native';
+
+import colors from '../../styles/colors';
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    backgroundColor: colors.lightGrey,
+    borderRadius: 4,
+    marginBottom: 16,
+    maxHeight: 100,
+    paddingLeft: 12,
+    paddingRight: 12,
+  },
+  textContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+});
+
+export default styles;

--- a/src/components/RecentSearchCard/styles.ts
+++ b/src/components/RecentSearchCard/styles.ts
@@ -1,24 +1,33 @@
 import { StyleSheet } from 'react-native';
 
-import colors from '../../styles/colors';
-
 const styles = StyleSheet.create({
   card: {
     flexDirection: 'row',
-    justifyContent: 'flex-start',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    backgroundColor: colors.lightGrey,
+    backgroundColor: 'white',
     borderRadius: 4,
-    marginBottom: 16,
+    marginTop: 8,
+    marginBottom: 8,
     maxHeight: 100,
     paddingLeft: 12,
     paddingRight: 12,
-    paddingBottom: 4,
-    paddingTop: 4,
+    paddingBottom: 10,
+    paddingTop: 10,
+    shadowColor: 'black',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.5,
+    elevation: 4,
   },
-  textContainer: {
+  leftItems: {
+    gap: 8,
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  rightItems: {
+    gap: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   searchValueText: {
     color: 'black',

--- a/src/components/RecentSearchCard/styles.ts
+++ b/src/components/RecentSearchCard/styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  card: {
+    flex: 1,
+    backgroundColor: 'white',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    paddingLeft: 24,
+    paddingRight: 24,
+  },
+  textContainer: {},
+  searchValueText: {},
+  numResultsText: {},
+});

--- a/src/queries/types.tsx
+++ b/src/queries/types.tsx
@@ -35,6 +35,6 @@ export interface StoryCard {
   featured_media: string;
 }
 export interface RecentSearch {
-  value: number;
+  value: string;
   numResults: number;
 }

--- a/src/queries/types.tsx
+++ b/src/queries/types.tsx
@@ -34,3 +34,7 @@ export interface StoryCard {
   author_name: string;
   featured_media: string;
 }
+export interface RecentSearch {
+  value: number;
+  numResults: number;
+}

--- a/src/queries/types.tsx
+++ b/src/queries/types.tsx
@@ -29,6 +29,6 @@ export interface Story {
 }
 
 export interface RecentSearch {
-  value: number;
+  value: string;
   numResults: number;
 }

--- a/src/queries/types.tsx
+++ b/src/queries/types.tsx
@@ -27,3 +27,8 @@ export interface Story {
   process: { html: string };
   link: string;
 }
+
+export interface RecentSearch {
+  value: number;
+  numResults: number;
+}


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
* Use Async Storage to save recentSearches whenever you leave the page or reopen the page
* When the SearchBar is empty, recentSearches are displayed with a max of 5 being displayed at a time
* 'Clear All' Button implemented to clear all recent searches

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links
N/A

### Notion Sprint Task
[https://www.notion.so/calblueprint/search-Implement-recent-searches-f3a74c8552cf42a5b46843d7d3a5c3f7](url)

[//]: # 'Add the relevant Notion link(s) here'

### Online sources
[https://react-native-async-storage.github.io/async-storage/docs/api/](url)
[https://react-native-async-storage.github.io/async-storage/docs/usage](url)
[https://reactnavigation.org/docs/use-is-focused/](url)
[https://stackoverflow.com/questions/72480134/cant-setstate-inside-useeffect-with-useisfocused-from-react-navigation-as-d](url)

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
N/A

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## How to review
* RecentSearchCard.tsx contains the component for every search card displayed when SearchBar is empty
* types.tsx has additional RecentSearch type which holds the value the search result (string) and the number of results (number)
* search/index.tsx: 
  * additional useState for recentSearches which is an array of RecentSearches type
  * clearRecentSearches function which clears al recentSearches when pressing button
  * searchResultStacking function handles the stack logic for the array, capping array at 5 elements, and taking valid searches
  * getRecentSearch function gets the array of recentSearches from Async Storage
  * setRecentSearch function sets the array of recentSearches to Async Storage under the key 'GWN_RECENT_SEARCHES_ARRAY'
  * New useEffect dependent on if user changes pages, then Async Storage gets set to the current array
  * return component has conditional display where recentSearches are displayed when the SearchBar is empty and search results are shown when the SearchBar has something typed

[//]: # 'The order in which to review files and what to expect when testing locally'

## Next steps
* Finish final styling with icons and spacing
* Implement button functionality whenever a RecentSearchCard is pressed in order to display search results

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

## Tests Performed, Edge Cases
* console.log the jsonValues in both getRecentSearch and setRecentSearch functions in order to test if values are being received/set to Async Storage when changing pages
* Search multiple items and make sure that list doesn't exceed length of 5
* When searching, search the same items to make sure stack logic is working properly and there are no duplicate searches being shown

[//]: # 'Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally'

### Screenshots

https://github.com/calblueprint/girls-write-now/assets/69034384/4d58b307-6ca5-4d9c-8fef-9e8d6b6693a8

[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @akshaynthakur

[//]: # 'This tags in Akshay as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
