### PR TITLE
[search] Implement recently viewed stories

### DIFF
--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -23,6 +23,42 @@ import { StoryPreview, RecentSearch, Genre } from '../../../queries/types';
 import colors from '../../../styles/colors';
 import globalStyles from '../../../styles/globalStyles';
 
+const getRecentSearch = async () => {
+  try {
+    const jsonValue = await AsyncStorage.getItem('GWN_RECENT_SEARCHES_ARRAY');
+    return jsonValue != null ? JSON.parse(jsonValue) : null;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+const setRecentSearch = async (searchResult: RecentSearch[]) => {
+  try {
+    const jsonValue = JSON.stringify(searchResult);
+    await AsyncStorage.setItem('GWN_RECENT_SEARCHES_ARRAY', jsonValue);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+const getRecentStory = async () => {
+  try {
+    const jsonValue = await AsyncStorage.getItem('GWN_RECENT_STORIES_ARRAY');
+    return jsonValue != null ? JSON.parse(jsonValue) : null;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+const setRecentStory = async (recentStories: StoryPreview[]) => {
+  try {
+    const jsonValue = JSON.stringify(recentStories);
+    await AsyncStorage.setItem('GWN_RECENT_STORIES_ARRAY', jsonValue);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
 function SearchScreen() {
   const [allStories, setAllStories] = useState<StoryPreview[]>([]);
   const [allGenres, setAllGenres] = useState<Genre[]>([]);
@@ -32,24 +68,7 @@ function SearchScreen() {
   const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
   const [showGenreCarousals, setShowGenreCarousals] = useState(true);
   const [showRecents, setShowRecents] = useState(false);
-
-  const getRecentSearch = async () => {
-    try {
-      const jsonValue = await AsyncStorage.getItem('GWN_RECENT_SEARCHES_ARRAY');
-      return jsonValue != null ? JSON.parse(jsonValue) : null;
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
-  const setRecentSearch = async (searchResult: RecentSearch[]) => {
-    try {
-      const jsonValue = JSON.stringify(searchResult);
-      await AsyncStorage.setItem('GWN_RECENT_SEARCHES_ARRAY', jsonValue);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const [recentlyViewed, setRecentlyViewed] = useState<StoryPreview[]>([]);
 
   useEffect(() => {
     (async () => {

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -119,7 +119,10 @@ function SearchScreen() {
     setRecentStory([]);
   };
 
-  const searchResultStacking = (searchString: string) => {
+  const searchResultStacking = (
+    searchString: string,
+    searchResults: number,
+  ) => {
     if (searchString !== '') {
       const maxArrayLength = 5;
 
@@ -138,7 +141,7 @@ function SearchScreen() {
 
       const result: RecentSearch = {
         value: searchString,
-        numResults: searchResults.length,
+        numResults: searchResults,
       };
 
       newRecentSearches.splice(0, 0, result);
@@ -203,7 +206,10 @@ function SearchScreen() {
             onChangeText={text => searchFunction(text)}
             value={search}
             onSubmitEditing={searchString => {
-              searchResultStacking(searchString.nativeEvent.text);
+              searchResultStacking(
+                searchString.nativeEvent.text,
+                searchResults.length,
+              );
             }}
           />
         </View>
@@ -238,8 +244,9 @@ function SearchScreen() {
                   value={item.value}
                   numResults={item.numResults}
                   pressFunction={() => {
-                    null;
-                  }} // add functionality
+                    searchFunction(item.value);
+                    searchResultStacking(item.value, item.numResults);
+                  }}
                 />
               ))}
             </View>

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -123,7 +123,7 @@ function SearchScreen() {
     if (searchString !== '') {
       const maxArrayLength = 5;
 
-      const newRecentSearches = recentSearches;
+      const newRecentSearches = [...recentSearches];
 
       for (let i = 0; i < recentSearches.length; i++) {
         if (searchString === recentSearches[i].value) {
@@ -150,7 +150,7 @@ function SearchScreen() {
 
   const recentlyViewedStacking = (story: StoryPreview) => {
     const maxArrayLength = 5;
-    const newRecentlyViewed = recentlyViewed;
+    const newRecentlyViewed = [...recentlyViewed];
 
     for (let i = 0; i < recentlyViewed.length; i++) {
       if (story.id === recentlyViewed[i].id) {
@@ -216,70 +216,61 @@ function SearchScreen() {
             />
           </View>
         )}
-
-        {showRecents && (
-          <>
-            {search ? (
-              <View style={styles.default}>
-                <Text style={[styles.searchText, styles.numDisplay]}>
-                  {searchResults.length}{' '}
-                  {searchResults.length === 1 ? 'Story' : 'Stories'}
-                </Text>
-              </View>
-            ) : (
-              <ScrollView>
-                <View style={styles.recentSpacing}>
-                  <Text style={styles.searchText}>Recent Searches</Text>
-                  <Pressable onPress={clearRecentSearches}>
-                    <Text style={styles.clearAll}>Clear All</Text>
-                  </Pressable>
-                </View>
-                <FlatList
-                  contentContainerStyle={styles.contentContainerRecents}
-                  showsVerticalScrollIndicator={false}
-                  data={recentSearches}
-                  renderItem={({ item }) => (
-                    <RecentSearchCard
-                      key={item.value}
-                      value={item.value}
-                      numResults={item.numResults}
-                      pressFunction={() => null}
-                    />
-                  )}
+        {search ? (
+          <View style={styles.default}>
+            <Text style={[styles.searchText, styles.numDisplay]}>
+              {searchResults.length}{' '}
+              {searchResults.length === 1 ? 'Story' : 'Stories'}
+            </Text>
+          </View>
+        ) : (
+          <ScrollView showsHorizontalScrollIndicator={false} bounces={false}>
+            <View style={styles.recentSpacing}>
+              <Text style={styles.searchText}>Recent Searches</Text>
+              <Pressable onPress={clearRecentSearches}>
+                <Text style={styles.clearAll}>Clear All</Text>
+              </Pressable>
+            </View>
+            <View style={styles.contentContainerRecents}>
+              {recentSearches.map(item => (
+                <RecentSearchCard
+                  key={item.value}
+                  value={item.value}
+                  numResults={item.numResults}
+                  pressFunction={() => {
+                    null;
+                  }} // add functionality
                 />
+              ))}
+            </View>
 
-                <View style={styles.recentSpacing}>
-                  <Text style={styles.searchText}>Recently Viewed</Text>
-                  <Pressable onPress={clearRecentlyViewed}>
-                    <Text style={styles.clearAll}>Clear All</Text>
-                  </Pressable>
-                </View>
-                <FlatList
-                  contentContainerStyle={styles.contentContainerRecents}
-                  showsVerticalScrollIndicator={false}
-                  data={recentlyViewed}
-                  renderItem={({ item }) => (
-                    <PreviewCard
-                      key={item.title}
-                      title={item.title}
-                      image={item.featured_media}
-                      author={item.author_name}
-                      authorImage={item.author_image}
-                      excerpt={item.excerpt}
-                      tags={item.genre_medium}
-                      pressFunction={() => {
-                        recentlyViewedStacking(item);
-                        router.push({
-                          pathname: '/story',
-                          params: { storyId: item.id.toString() },
-                        });
-                      }}
-                    />
-                  )}
+            <View style={styles.recentSpacing}>
+              <Text style={styles.searchText}>Recently Viewed</Text>
+              <Pressable onPress={clearRecentlyViewed}>
+                <Text style={styles.clearAll}>Clear All</Text>
+              </Pressable>
+            </View>
+            <View style={styles.contentContainerRecents}>
+              {recentlyViewed.map(item => (
+                <PreviewCard
+                  key={item.title}
+                  title={item.title}
+                  image={item.featured_media}
+                  author={item.author_name}
+                  authorImage={item.author_image}
+                  excerpt={item.excerpt}
+                  tags={item.genre_medium}
+                  pressFunction={() => {
+                    recentlyViewedStacking(item);
+                    router.push({
+                      pathname: '/story',
+                      params: { storyId: item.id.toString() },
+                    });
+                  }}
                 />
-              </ScrollView>
-            )}
-          </>
+              ))}
+            </View>
+          </ScrollView>
         )}
 
         {showGenreCarousals ? (

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -43,7 +43,7 @@ const setRecentSearch = async (searchResult: RecentSearch[]) => {
 
 const getRecentStory = async () => {
   try {
-    const jsonValue = await AsyncStorage.getItem('GWN_RECENTLY_VIEWED_ARRAY');
+    const jsonValue = await AsyncStorage.getItem('GWN_RECENT_STORIES_ARRAY');
     return jsonValue != null ? JSON.parse(jsonValue) : null;
   } catch (error) {
     console.log(error);
@@ -53,7 +53,7 @@ const getRecentStory = async () => {
 const setRecentStory = async (recentStories: StoryPreview[]) => {
   try {
     const jsonValue = JSON.stringify(recentStories);
-    await AsyncStorage.setItem('GWN_RECENTLY_VIEWED_ARRAY', jsonValue);
+    await AsyncStorage.setItem('GWN_RECENT_STORIES_ARRAY', jsonValue);
   } catch (error) {
     console.log(error);
   }

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -183,36 +183,34 @@ function SearchScreen() {
     >
       <View style={[filterVisible ? styles.greyOverlay : styles.noOverlay]} />
       <View style={styles.container}>
-        <View style={styles.default}>
-          <SearchBar
-            platform="ios"
-            onCancel={() => handleCancelButtonPress()}
-            onFocus={() => {
-              setShowRecents(true);
-              setShowGenreCarousals(false);
-            }}
-            searchIcon={false}
-            clearIcon
-            containerStyle={[
-              styles.searchContainer,
-              showGenreCarousals && { marginRight: 16 },
-            ]}
-            inputContainerStyle={styles.inputContainer}
-            inputStyle={{ color: 'black' }}
-            leftIconContainerStyle={{}}
-            rightIconContainerStyle={{}}
-            placeholder="Search"
-            placeholderTextColor="black"
-            onChangeText={text => searchFunction(text)}
-            value={search}
-            onSubmitEditing={searchString => {
-              searchResultStacking(
-                searchString.nativeEvent.text,
-                searchResults.length,
-              );
-            }}
-          />
-        </View>
+        <SearchBar
+          platform="ios"
+          onCancel={() => handleCancelButtonPress()}
+          onFocus={() => {
+            setShowRecents(true);
+            setShowGenreCarousals(false);
+          }}
+          searchIcon={false}
+          clearIcon
+          containerStyle={[
+            styles.searchContainer,
+            showGenreCarousals && { marginRight: 24 },
+          ]}
+          inputContainerStyle={styles.inputContainer}
+          inputStyle={{ color: 'black' }}
+          leftIconContainerStyle={{}}
+          rightIconContainerStyle={{}}
+          placeholder="Search"
+          placeholderTextColor="black"
+          onChangeText={text => searchFunction(text)}
+          value={search}
+          onSubmitEditing={searchString => {
+            searchResultStacking(
+              searchString.nativeEvent.text,
+              searchResults.length,
+            );
+          }}
+        />
 
         {search && (
           <View style={styles.default}>
@@ -222,63 +220,65 @@ function SearchScreen() {
             />
           </View>
         )}
-        {search ? (
-          <View style={styles.default}>
-            <Text style={[styles.searchText, styles.numDisplay]}>
-              {searchResults.length}{' '}
-              {searchResults.length === 1 ? 'Story' : 'Stories'}
-            </Text>
-          </View>
-        ) : (
-          <ScrollView showsVerticalScrollIndicator={false} bounces={false}>
-            <View style={styles.recentSpacing}>
-              <Text style={styles.searchText}>Recent Searches</Text>
-              <Pressable onPress={clearRecentSearches}>
-                <Text style={styles.clearAll}>Clear All</Text>
-              </Pressable>
-            </View>
-            <View style={styles.contentContainerRecents}>
-              {recentSearches.map(item => (
-                <RecentSearchCard
-                  key={item.value}
-                  value={item.value}
-                  numResults={item.numResults}
-                  pressFunction={() => {
-                    searchFunction(item.value);
-                    searchResultStacking(item.value, item.numResults);
-                  }}
-                />
-              ))}
-            </View>
 
-            <View style={styles.recentSpacing}>
-              <Text style={styles.searchText}>Recently Viewed</Text>
-              <Pressable onPress={clearRecentlyViewed}>
-                <Text style={styles.clearAll}>Clear All</Text>
-              </Pressable>
+        {showRecents &&
+          (search ? (
+            <View style={styles.default}>
+              <Text style={[styles.searchText, styles.numDisplay]}>
+                {searchResults.length}{' '}
+                {searchResults.length === 1 ? 'Story' : 'Stories'}
+              </Text>
             </View>
-            <View style={styles.contentContainerRecents}>
-              {recentlyViewed.map(item => (
-                <PreviewCard
-                  key={item.title}
-                  title={item.title}
-                  image={item.featured_media}
-                  author={item.author_name}
-                  authorImage={item.author_image}
-                  excerpt={item.excerpt}
-                  tags={item.genre_medium}
-                  pressFunction={() => {
-                    recentlyViewedStacking(item);
-                    router.push({
-                      pathname: '/story',
-                      params: { storyId: item.id.toString() },
-                    });
-                  }}
-                />
-              ))}
-            </View>
-          </ScrollView>
-        )}
+          ) : (
+            <ScrollView showsVerticalScrollIndicator={false} bounces={false}>
+              <View style={styles.recentSpacing}>
+                <Text style={styles.searchText}>Recent Searches</Text>
+                <Pressable onPress={clearRecentSearches}>
+                  <Text style={styles.clearAll}>Clear All</Text>
+                </Pressable>
+              </View>
+              <View style={styles.contentContainerRecents}>
+                {recentSearches.map(item => (
+                  <RecentSearchCard
+                    key={item.value}
+                    value={item.value}
+                    numResults={item.numResults}
+                    pressFunction={() => {
+                      searchFunction(item.value);
+                      searchResultStacking(item.value, item.numResults);
+                    }}
+                  />
+                ))}
+              </View>
+
+              <View style={styles.recentSpacing}>
+                <Text style={styles.searchText}>Recently Viewed</Text>
+                <Pressable onPress={clearRecentlyViewed}>
+                  <Text style={styles.clearAll}>Clear All</Text>
+                </Pressable>
+              </View>
+              <View style={styles.contentContainerRecents}>
+                {recentlyViewed.map(item => (
+                  <PreviewCard
+                    key={item.title}
+                    title={item.title}
+                    image={item.featured_media}
+                    author={item.author_name}
+                    authorImage={item.author_image}
+                    excerpt={item.excerpt}
+                    tags={item.genre_medium}
+                    pressFunction={() => {
+                      recentlyViewedStacking(item);
+                      router.push({
+                        pathname: '/story',
+                        params: { storyId: item.id.toString() },
+                      });
+                    }}
+                  />
+                ))}
+              </View>
+            </ScrollView>
+          ))}
 
         {showGenreCarousals ? (
           <ScrollView
@@ -322,12 +322,13 @@ function SearchScreen() {
                 authorImage={item.author_image}
                 excerpt={item.excerpt}
                 tags={item.genre_medium}
-                pressFunction={() =>
+                pressFunction={() => {
+                  recentlyViewedStacking(item);
                   router.push({
                     pathname: '/story',
                     params: { storyId: item.id.toString() },
-                  })
-                }
+                  });
+                }}
               />
             )}
           />

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -230,7 +230,7 @@ function SearchScreen() {
             </Text>
           </View>
         ) : (
-          <ScrollView showsHorizontalScrollIndicator={false} bounces={false}>
+          <ScrollView showsVerticalScrollIndicator={false} bounces={false}>
             <View style={styles.recentSpacing}>
               <Text style={styles.searchText}>Recent Searches</Text>
               <Pressable onPress={clearRecentSearches}>

--- a/src/app/(tabs)/search/index.tsx
+++ b/src/app/(tabs)/search/index.tsx
@@ -43,7 +43,7 @@ const setRecentSearch = async (searchResult: RecentSearch[]) => {
 
 const getRecentStory = async () => {
   try {
-    const jsonValue = await AsyncStorage.getItem('GWN_RECENT_STORIES_ARRAY');
+    const jsonValue = await AsyncStorage.getItem('GWN_RECENTLY_VIEWED_ARRAY');
     return jsonValue != null ? JSON.parse(jsonValue) : null;
   } catch (error) {
     console.log(error);
@@ -53,7 +53,7 @@ const getRecentStory = async () => {
 const setRecentStory = async (recentStories: StoryPreview[]) => {
   try {
     const jsonValue = JSON.stringify(recentStories);
-    await AsyncStorage.setItem('GWN_RECENT_STORIES_ARRAY', jsonValue);
+    await AsyncStorage.setItem('GWN_RECENTLY_VIEWED_ARRAY', jsonValue);
   } catch (error) {
     console.log(error);
   }
@@ -77,6 +77,7 @@ function SearchScreen() {
       const genreData: Genre[] = await fetchGenres();
       setAllGenres(genreData);
       setRecentSearches(await getRecentSearch());
+      setRecentlyViewed(await getRecentStory());
     })();
   }, []);
 

--- a/src/app/(tabs)/search/styles.ts
+++ b/src/app/(tabs)/search/styles.ts
@@ -47,7 +47,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginTop: 0,
+    marginTop: 8,
     marginBottom: 8,
     marginHorizontal: 8,
   },

--- a/src/app/(tabs)/search/styles.ts
+++ b/src/app/(tabs)/search/styles.ts
@@ -70,7 +70,6 @@ const styles = StyleSheet.create({
   },
   contentCotainerStories: {
     paddingHorizontal: 8,
-    paddingBottom: 24,
   },
   genreText: {
     flexDirection: 'row',

--- a/src/app/(tabs)/search/styles.ts
+++ b/src/app/(tabs)/search/styles.ts
@@ -10,15 +10,11 @@ const styles = StyleSheet.create({
     marginTop: 24,
     flex: 1,
   },
-  default: {
-    paddingHorizontal: 8,
-  },
   searchContainer: {
     backgroundColor: 'transparent',
     borderRadius: 10,
     borderColor: 'transparent',
-    marginHorizontal: -8,
-    marginBottom: 16,
+    marginBottom: 8,
   },
   inputContainer: {
     backgroundColor: '#D9D9D9',
@@ -31,9 +27,10 @@ const styles = StyleSheet.create({
     top: 0,
     opacity: 0.2,
     backgroundColor: 'black',
-    width,
+    width: '200%',
     height,
     zIndex: 1,
+    marginRight: -16,
   },
   noOverlay: {
     flex: 1,

--- a/src/app/(tabs)/search/styles.ts
+++ b/src/app/(tabs)/search/styles.ts
@@ -10,6 +10,9 @@ const styles = StyleSheet.create({
     marginTop: 24,
     flex: 1,
   },
+  default: {
+    paddingHorizontal: 8,
+  },
   searchContainer: {
     backgroundColor: 'transparent',
     borderRadius: 10,

--- a/src/app/(tabs)/search/styles.ts
+++ b/src/app/(tabs)/search/styles.ts
@@ -66,6 +66,7 @@ const styles = StyleSheet.create({
   },
   contentContainerRecents: {
     paddingHorizontal: 8,
+    marginBottom: 8,
   },
   contentCotainerStories: {
     paddingHorizontal: 8,


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

# What's new in this PR
* Use Async Storage to save recentlyViewed stories every time a new story is viewed
* When the SearchBar is empty, recentlyViewed stories are displayed with a max of 5 being displayed at one time
* 'Clear All' Button implemented to clear all recentlyViewed stories
* recentSearches SearchCards are now pressable to search and redoes stack ordering

[//]: # "Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

## Relevant Links
N/A

### Notion Sprint Task
[https://www.notion.so/calblueprint/search-Implement-recently-viewed-stories-7f5b8fbf5e0d4b94905d6e29f4e3f42d](url)

[//]: # 'Add the relevant Notion link(s) here'

### Online sources
[https://react-native-async-storage.github.io/async-storage/docs/api/](url)
[https://react-native-async-storage.github.io/async-storage/docs/usage/](url)

[//]: # 'Optional - copy links to any tutorial or documentation that was useful to you when working on this PR'

### Related PRs
[https://github.com/calblueprint/girls-write-now/pull/41](url)
- Implemented recent Searches which uses the same logic for recentlyViewed stories

[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## How to review
* types.tsx shows the type of StoryPreview which is used to display recentlyViewed stories
* search/index.tsx:
  * additional useState recentlyViewed added which is a StoryPreview type array
  * clearRecentlyViewed function which clears al recentlyViewed stories when pressing button 'Clear All'
  * recentlyViewedStacking function handles the stack logic for the array, capping array at 5 elements, and setting Async Storage to updated array
  * getRecentStory function gets the array of recentlyViewed from Async Storage
  * setRecentStory function sets the array of recentlyViewed to Async Storage under the key 'GWN_RECENTLY_VIEWED_ARRAY'
  * return component has conditional display where recentlyViewed are displayed when the SearchBar is empty and search results are shown when the SearchBar has something typed

[//]: # 'The order in which to review files and what to expect when testing locally'

## Next steps
N/A

[//]: # "What's NOT in this PR, doesn't work yet, and/or still needs to be done"

## Tests Performed, Edge Cases

- [x] Calling recentlyViewedStacking function when pressing SearchCard for recentlyViewed stories does not work properly. If a duplicate story is pressed, it is not moved to the top of the stack (start of array). The array essentially does not change and stays the same. However, it works fine when being called after pressing a SearchCard when stories are filtered by the SearchBar input. Specifically, duplicates are put to the top of the stack and the array is still kept to a max of length 5. (FIXED IN LAST COMMIT)

[//]: # 'Hopefully we will add a testing suite/CI soon, but until then note down the steps you took to test locally'

### Screenshots

https://github.com/calblueprint/girls-write-now/assets/69034384/9f5caa3b-da07-4c32-a90d-bfa535756fdc

https://github.com/calblueprint/girls-write-now/assets/69034384/a8476dfb-de7f-4de0-a50b-ccbf462c0322


[//]: # "Add screenshots of expected behavior - GIFs if you're feeling fancy!"

CC: @akshaynthakur

[//]: # 'This tags in Akshay as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
